### PR TITLE
Feature: tags

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -20,6 +20,7 @@ mod snooze;
 mod snoozed;
 mod split;
 mod status;
+mod tag;
 pub mod todo;
 mod top;
 mod unblock;
@@ -93,6 +94,9 @@ mod split_test;
 
 #[cfg(test)]
 mod status_test;
+
+#[cfg(test)]
+mod tag_test;
 
 #[cfg(test)]
 mod top_test;

--- a/app/src/log.rs
+++ b/app/src/log.rs
@@ -5,7 +5,7 @@ use {
     printing::{LogDate, TodoPrinter},
 };
 
-pub fn run<'a>(list: &TodoList, printer: &mut impl TodoPrinter) {
+pub fn run(list: &TodoList, printer: &mut impl TodoPrinter) {
     let mut most_recent_shown = None;
     list.complete_tasks().for_each(|id| {
         let mut formatted_task = format_task(list, id);

--- a/app/src/merge.rs
+++ b/app/src/merge.rs
@@ -71,6 +71,12 @@ pub fn run(
         .map(|id| list.get(id).unwrap().start_date)
         .max()
         .unwrap_or(now);
+    let tag = match cmd.tag {
+        Some(value) => value,
+        None => tasks_to_merge
+            .iter_unsorted()
+            .all(|id| list.get(id).map_or_else(|| true, |data| data.tag)),
+    };
     let merged = list.add(NewOptions {
         desc: Cow::Owned(cmd.into.to_string()),
         now,
@@ -78,7 +84,7 @@ pub fn run(
         due_date,
         budget,
         start_date,
-        tag: false,
+        tag,
     });
     deps.iter_sorted(list).for_each(|dep| {
         // This shouldn't panic if we correctly detected cycles above.

--- a/app/src/merge.rs
+++ b/app/src/merge.rs
@@ -78,6 +78,7 @@ pub fn run(
         due_date,
         budget,
         start_date,
+        tag: false,
     });
     deps.iter_sorted(list).for_each(|dep| {
         // This shouldn't panic if we correctly detected cycles above.

--- a/app/src/merge_test.rs
+++ b/app/src/merge_test.rs
@@ -175,3 +175,72 @@ fn merge_snoozed_tasks() {
         )
         .end();
 }
+
+#[test]
+fn merge_tags_default() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --tag");
+    fix.test("todo merge a b c --into abc")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("abc", 1, Incomplete)
+                .action(Select)
+                .as_tag(),
+        )
+        .end();
+}
+
+#[test]
+fn merge_tags_into_tag() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --tag");
+    fix.test("todo merge a b c --into abc --tag true")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("abc", 1, Incomplete)
+                .action(Select)
+                .as_tag(),
+        )
+        .end();
+}
+
+#[test]
+fn merge_tasks_into_tag() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c");
+    fix.test("todo merge a b c --into abc --tag true")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("abc", 1, Incomplete)
+                .action(Select)
+                .as_tag(),
+        )
+        .end();
+}
+
+#[test]
+fn merge_tags_into_task() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --tag");
+    fix.test("todo merge a b c --into abc --tag false")
+        .validate()
+        .printed_task(&PrintableTask::new("abc", 1, Incomplete).action(Select))
+        .end();
+}
+
+#[test]
+fn show_tags_for_merged_task() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --tag");
+    fix.test("todo block c --on a b");
+    fix.test("todo merge a b --into ab")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("ab", 1, Incomplete)
+                .action(Select)
+                .as_tag()
+                .tag("c"),
+        )
+        .printed_task(&PrintableTask::new("c", 2, Blocked).as_tag())
+        .end();
+}

--- a/app/src/new.rs
+++ b/app/src/new.rs
@@ -57,6 +57,7 @@ pub fn run(
                 due_date,
                 budget,
                 start_date: snooze_date,
+                tag: cmd.tag,
             });
             to_print.insert(id);
             id

--- a/app/src/new_test.rs
+++ b/app/src/new_test.rs
@@ -602,3 +602,82 @@ fn new_transitively_block_completed_task() {
         .printed_task(&PrintableTask::new("c", 3, Blocked))
         .end();
 }
+
+#[test]
+fn new_as_tag() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --tag")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete).action(New).as_tag(),
+        )
+        .end();
+}
+
+#[test]
+fn new_multiple_as_tag() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --tag")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete).action(New).as_tag(),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Incomplete).action(New).as_tag(),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 3, Incomplete).action(New).as_tag(),
+        )
+        .end();
+}
+
+#[test]
+fn new_blocking_tag() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --tag");
+    fix.test("todo new b -b a")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("b", 1, Incomplete).action(New).tag("a"),
+        )
+        .printed_task(&PrintableTask::new("a", 2, Blocked).as_tag())
+        .end();
+}
+
+#[test]
+fn new_tag_blocking_tag() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --tag");
+    fix.test("todo new b -b a --tag")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("b", 1, Incomplete)
+                .action(New)
+                .tag("a")
+                .as_tag(),
+        )
+        .printed_task(&PrintableTask::new("a", 2, Blocked).as_tag())
+        .end();
+}
+
+#[test]
+fn new_tag_chain() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain --tag")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(New)
+                .tag("c")
+                .tag("b")
+                .as_tag(),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(New)
+                .tag("c")
+                .as_tag(),
+        )
+        .printed_task(&PrintableTask::new("c", 3, Blocked).action(New).as_tag())
+        .end();
+}

--- a/app/src/split.rs
+++ b/app/src/split.rs
@@ -31,7 +31,12 @@ fn split(
     into: Vec<String>,
     chain: bool,
     keep: bool,
+    tag: Option<bool>,
 ) -> SplitResult {
+    let original_is_tag = match list.get(id) {
+        Some(task) => task.tag,
+        None => false,
+    };
     let deps: Vec<_> = list.deps(id).iter_sorted(list).collect();
     let adeps: Vec<_> = list.adeps(id).iter_sorted(list).collect();
     let num_shards: u32 = into.len().try_into().unwrap();
@@ -50,7 +55,10 @@ fn split(
                     task.budget
                 },
                 start_date: task.start_date,
-                tag: false,
+                tag: match tag {
+                    Some(value) => value,
+                    None => !keep && original_is_tag,
+                },
             };
             list.add(options)
         })
@@ -104,6 +112,7 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: Split) {
                     .collect(),
                 cmd.chain,
                 cmd.keep,
+                cmd.tag,
             ))
         },
     );

--- a/app/src/split.rs
+++ b/app/src/split.rs
@@ -50,6 +50,7 @@ fn split(
                     task.budget
                 },
                 start_date: task.start_date,
+                tag: false,
             };
             list.add(options)
         })

--- a/app/src/split_test.rs
+++ b/app/src/split_test.rs
@@ -211,3 +211,40 @@ fn split_task_chain_keep_with_budget() {
         .printed_task(&PrintableTask::new("a", 4, Blocked).action(Select))
         .end();
 }
+
+#[test]
+fn split_tag_default() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --tag");
+    fix.test("todo split a --into x y z")
+        .validate()
+        .printed_task(&PrintableTask::new("x", 1, Incomplete).action(New).as_tag())
+        .printed_task(&PrintableTask::new("y", 2, Incomplete).action(New).as_tag())
+        .printed_task(&PrintableTask::new("z", 3, Incomplete).action(New).as_tag())
+        .end();
+}
+
+#[test]
+fn split_tag_into_non_tags() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --tag");
+    fix.test("todo split a --into x y z --tag false")
+        .validate()
+        .printed_task(&PrintableTask::new("x", 1, Incomplete).action(New))
+        .printed_task(&PrintableTask::new("y", 2, Incomplete).action(New))
+        .printed_task(&PrintableTask::new("z", 3, Incomplete).action(New))
+        .end();
+}
+
+#[test]
+fn split_tag_keep() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --tag");
+    fix.test("todo split a --into x y z --keep")
+        .validate()
+        .printed_task(&PrintableTask::new("x", 1, Incomplete).action(New).tag("a"))
+        .printed_task(&PrintableTask::new("y", 2, Incomplete).action(New).tag("a"))
+        .printed_task(&PrintableTask::new("z", 3, Incomplete).action(New).tag("a"))
+        .printed_task(&PrintableTask::new("a", 4, Blocked).action(Select).as_tag())
+        .end();
+}

--- a/app/src/tag.rs
+++ b/app/src/tag.rs
@@ -1,0 +1,61 @@
+use {
+    super::util::{format_task, lookup_tasks},
+    cli::Tag,
+    model::{TaskSet, TaskStatus, TodoList},
+    printing::{Action, TodoPrinter},
+};
+
+fn print_all_tags(
+    list: &TodoList,
+    printer: &mut impl TodoPrinter,
+    include_done: bool,
+) {
+    list.all_tasks()
+        .filter(|&id| {
+            if let (Some(data), Some(status)) = (list.get(id), list.status(id))
+            {
+                return data.tag
+                    && (include_done || status != TaskStatus::Complete);
+            }
+            false
+        })
+        .for_each(|id| {
+            let task = format_task(list, id);
+            printer.print_task(&task.action(Action::None));
+        });
+}
+
+fn mark_tasks(
+    list: &mut TodoList,
+    tasks_to_mark: &TaskSet,
+    tag: bool,
+) -> TaskSet {
+    tasks_to_mark
+        .iter_sorted(list)
+        .fold(TaskSet::default(), |so_far, id| {
+            so_far | list.set_tag(id, tag)
+        })
+}
+
+pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Tag) {
+    if cmd.keys.is_empty() && cmd.unmark.is_empty() {
+        print_all_tags(list, printer, cmd.include_done);
+        return;
+    }
+    let tasks_to_mark = lookup_tasks(list, &cmd.keys);
+    let tasks_to_unmark = lookup_tasks(list, &cmd.unmark);
+    (mark_tasks(list, &tasks_to_mark, true)
+        | mark_tasks(list, &tasks_to_unmark, false))
+    .include_done(list, cmd.include_done)
+    .iter_sorted(list)
+    .for_each(|id| {
+        let task = format_task(list, id);
+        printer.print_task(&task.action(
+            if tasks_to_mark.contains(id) || tasks_to_unmark.contains(id) {
+                Action::Select
+            } else {
+                Action::None
+            },
+        ));
+    });
+}

--- a/app/src/tag_test.rs
+++ b/app/src/tag_test.rs
@@ -1,0 +1,227 @@
+use {
+    super::testing::Fixture,
+    printing::{Action::*, PrintableTask, Status::*},
+};
+
+#[test]
+fn tag_show_no_tags() {
+    let mut fix = Fixture::default();
+    fix.test("todo tag").validate().end();
+}
+
+#[test]
+fn tag_show_all_tags() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --tag");
+    fix.test("todo new d e f");
+    fix.test("todo tag")
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).as_tag())
+        .printed_task(&PrintableTask::new("b", 2, Incomplete).as_tag())
+        .printed_task(&PrintableTask::new("c", 3, Incomplete).as_tag())
+        .end();
+}
+
+#[test]
+fn tag_show_blocked_tags() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --tag --chain");
+    fix.test("todo tag")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .tag("c")
+                .tag("b")
+                .as_tag(),
+        )
+        .printed_task(&PrintableTask::new("b", 2, Blocked).tag("c").as_tag())
+        .printed_task(&PrintableTask::new("c", 3, Blocked).as_tag())
+        .end();
+}
+
+#[test]
+fn tag_does_not_show_complete_tags_by_default() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --tag");
+    fix.test("todo check a");
+    fix.test("todo tag")
+        .validate()
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).as_tag())
+        .printed_task(&PrintableTask::new("c", 2, Incomplete).as_tag())
+        .end();
+}
+
+#[test]
+fn tag_show_complete_tags() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --tag");
+    fix.test("todo check a");
+    fix.test("todo tag --include-done")
+        .validate()
+        .printed_task(&PrintableTask::new("a", 0, Complete).as_tag())
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).as_tag())
+        .printed_task(&PrintableTask::new("c", 2, Incomplete).as_tag())
+        .end();
+}
+
+#[test]
+fn tag_mark_single() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c");
+    fix.test("todo tag a")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .as_tag(),
+        )
+        .end();
+}
+
+#[test]
+fn tag_mark_multiple() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c");
+    fix.test("todo tag a b")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .as_tag(),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Incomplete)
+                .action(Select)
+                .as_tag(),
+        )
+        .end();
+}
+
+#[test]
+fn tag_mark_already_tag() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c");
+    fix.test("todo tag a")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .as_tag(),
+        )
+        .end();
+    fix.test("todo tag a").validate().end();
+}
+
+#[test]
+fn tag_prints_affected_deps_when_marking() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo tag c")
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).tag("c"))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).tag("c"))
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked).action(Select).as_tag(),
+        )
+        .end();
+}
+
+#[test]
+fn tag_unmark_single() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --tag");
+    fix.test("todo tag -u a")
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
+        .end();
+}
+
+#[test]
+fn tag_unmark_multiple() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --tag");
+    fix.test("todo tag -u a b")
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
+        .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Select))
+        .end();
+}
+
+#[test]
+fn tag_unmark_already_unmarked() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a");
+    fix.test("todo tag -u a").validate().end();
+}
+
+#[test]
+fn tag_mark_and_unmark() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a");
+    fix.test("todo new b --tag");
+    fix.test("todo tag a -u b")
+        .validate()
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .as_tag(),
+        )
+        .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Select))
+        .end();
+}
+
+#[test]
+fn tag_does_not_show_complete_deps_by_default_when_marking() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo check a");
+    fix.test("todo tag c")
+        .validate()
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).tag("c"))
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked).action(Select).as_tag(),
+        )
+        .end();
+}
+
+#[test]
+fn tag_show_complete_deps_when_marking() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo check a");
+    fix.test("todo tag c --include-done")
+        .validate()
+        .printed_task(&PrintableTask::new("a", 0, Complete).tag("c"))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).tag("c"))
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked).action(Select).as_tag(),
+        )
+        .end();
+}
+
+#[test]
+fn tag_does_not_show_complete_deps_by_default_when_unmarking() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo tag c");
+    fix.test("todo check a");
+    fix.test("todo tag -u c")
+        .validate()
+        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&PrintableTask::new("c", 2, Blocked).action(Select))
+        .end();
+}
+
+#[test]
+fn tag_show_complete_deps_when_unmarking() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo tag c");
+    fix.test("todo check a");
+    fix.test("todo tag -u c -d")
+        .validate()
+        .printed_task(&PrintableTask::new("a", 0, Complete))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&PrintableTask::new("c", 2, Blocked).action(Select))
+        .end();
+}

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -2,7 +2,7 @@ use {
     super::{
         block, budget, chain, check, due, edit, find, get, log, merge, new,
         path, prefix, priority, punt, put, restore, rm, snooze, snoozed, split,
-        status, top, unblock, unsnooze,
+        status, tag, top, unblock, unsnooze,
     },
     cli::{Options, SubCommand},
     clock::Clock,
@@ -50,6 +50,7 @@ pub fn todo(
         Some(Snooze(cmd)) => snooze::run(list, printer, now, &cmd),
         Some(Snoozed(_)) => snoozed::run(list, printer, now),
         Some(Split(cmd)) => split::run(list, printer, cmd),
+        Some(Tag(cmd)) => tag::run(list, printer, &cmd),
         Some(Top(cmd)) => top::run(list, printer, &cmd),
         Some(Unblock(cmd)) => unblock::run(list, printer, &cmd),
         Some(Unsnooze(cmd)) => unsnooze::run(list, printer, &cmd),

--- a/app/src/util.rs
+++ b/app/src/util.rs
@@ -136,6 +136,14 @@ pub fn format_task<'ser, 'list>(
             if task.start_date > task.creation_time {
                 result = result.start_date(task.start_date);
             }
+            if task.tag {
+                result = result.as_tag();
+            }
+            for tag_id in &task.implicit_tags {
+                if let Some(tag_data) = list.get(*tag_id) {
+                    result = result.tag(&tag_data.desc);
+                }
+            }
             wrap(result)
                 .add_deps_if_necessary(list, id, status)
                 .add_adeps_if_necessary(list, id, status)

--- a/app/src/util_test.rs
+++ b/app/src/util_test.rs
@@ -275,6 +275,48 @@ fn format_complete_task_with_punctuality_late() {
 }
 
 #[test]
+fn format_tag() {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    let actual = format_task(&list, a);
+    let expected = PrintableTask::new("a", 1, Incomplete).as_tag();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn format_task_with_implicit_tags() {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    let b = list.add(NewOptions::new().desc("b").as_tag());
+    let c = list.add("c");
+    list.block(a).on(c).unwrap();
+    list.block(b).on(c).unwrap();
+    let actual = format_task(&list, c);
+    let expected = PrintableTask::new("c", 1, Incomplete)
+        .adeps_stats(2, 2)
+        .tag("a")
+        .tag("b");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn format_tag_with_implicit_tags() {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    let b = list.add(NewOptions::new().desc("b").as_tag());
+    let c = list.add(NewOptions::new().desc("c").as_tag());
+    list.block(a).on(c).unwrap();
+    list.block(b).on(c).unwrap();
+    let actual = format_task(&list, c);
+    let expected = PrintableTask::new("c", 1, Incomplete)
+        .adeps_stats(2, 2)
+        .tag("a")
+        .tag("b")
+        .as_tag();
+    assert_eq!(actual, expected);
+}
+
+#[test]
 fn lookup_by_number() {
     let mut list = TodoList::default();
     let a = list.add("a");

--- a/cli/src/subcommand.rs
+++ b/cli/src/subcommand.rs
@@ -35,6 +35,7 @@ pub enum SubCommand {
     Snooze(Snooze),
     Snoozed(Snoozed),
     Split(Split),
+    Tag(Tag),
     Top(Top),
     Unblock(Unblock),
     Unsnooze(Unsnooze),

--- a/cli/src/subcommands/merge.rs
+++ b/cli/src/subcommands/merge.rs
@@ -8,7 +8,7 @@ use {clap::Parser, lookup_key::Key};
 /// the constituents.
 ///
 /// This is the opposite of 'split'.
-#[derive(Debug, PartialEq, Parser)]
+#[derive(Debug, Default, PartialEq, Parser)]
 #[clap(allow_negative_numbers(true), verbatim_doc_comment)]
 pub struct Merge {
     /// Tasks to merge.
@@ -17,4 +17,11 @@ pub struct Merge {
     /// Description of new task to merge into.
     #[clap(long)]
     pub into: String,
+    /// If passed with a value of "true", the new task will be marked as a tag.
+    /// If passed with a value of "false", the new task will not be marked as a
+    /// tag. If not passed, the new task will be marked as a tag if all of the
+    /// original tasks were marked as tags, otherwise it will not be marked as
+    /// a tag.
+    #[clap(long, short = 't')]
+    pub tag: Option<bool>,
 }

--- a/cli/src/subcommands/merge_test.rs
+++ b/cli/src/subcommands/merge_test.rs
@@ -21,6 +21,7 @@ fn merge_one() {
         SubCommand::Merge(Merge {
             keys: vec![ByNumber(1)],
             into: "aa".to_string(),
+            ..Default::default()
         }),
     );
 }
@@ -32,6 +33,7 @@ fn merge_two() {
         SubCommand::Merge(Merge {
             keys: vec![ByNumber(1), ByNumber(2)],
             into: "ab".to_string(),
+            ..Default::default()
         }),
     );
 }
@@ -43,6 +45,55 @@ fn merge_three() {
         SubCommand::Merge(Merge {
             keys: vec![ByNumber(-1), ByNumber(-2), ByNumber(-3)],
             into: "abc".to_string(),
+            ..Default::default()
         }),
     );
+}
+
+#[test]
+fn merge_into_tag_true_long() {
+    expect_parses_into(
+        "todo merge 1 2 --into c --tag true",
+        SubCommand::Merge(Merge {
+            keys: vec![ByNumber(1), ByNumber(2)],
+            into: "c".to_string(),
+            tag: Some(true),
+        }),
+    )
+}
+
+#[test]
+fn merge_into_tag_false_long() {
+    expect_parses_into(
+        "todo merge 1 2 --into c --tag false",
+        SubCommand::Merge(Merge {
+            keys: vec![ByNumber(1), ByNumber(2)],
+            into: "c".to_string(),
+            tag: Some(false),
+        }),
+    )
+}
+
+#[test]
+fn merge_into_tag_true_short() {
+    expect_parses_into(
+        "todo merge 1 2 --into c -t true",
+        SubCommand::Merge(Merge {
+            keys: vec![ByNumber(1), ByNumber(2)],
+            into: "c".to_string(),
+            tag: Some(true),
+        }),
+    )
+}
+
+#[test]
+fn merge_into_tag_false_short() {
+    expect_parses_into(
+        "todo merge 1 2 --into c -t false",
+        SubCommand::Merge(Merge {
+            keys: vec![ByNumber(1), ByNumber(2)],
+            into: "c".to_string(),
+            tag: Some(false),
+        }),
+    )
 }

--- a/cli/src/subcommands/mod.rs
+++ b/cli/src/subcommands/mod.rs
@@ -19,6 +19,7 @@ mod rm;
 mod snooze;
 mod snoozed;
 mod split;
+mod tag;
 mod top;
 mod unblock;
 mod unsnooze;
@@ -44,6 +45,7 @@ pub use self::rm::Rm;
 pub use self::snooze::Snooze;
 pub use self::snoozed::Snoozed;
 pub use self::split::Split;
+pub use self::tag::Tag;
 pub use self::top::Top;
 pub use self::unblock::Unblock;
 pub use self::unsnooze::Unsnooze;
@@ -110,6 +112,9 @@ mod snoozed_test;
 
 #[cfg(test)]
 mod split_test;
+
+#[cfg(test)]
+mod tag_test;
 
 #[cfg(test)]
 mod top_test;

--- a/cli/src/subcommands/new.rs
+++ b/cli/src/subcommands/new.rs
@@ -138,7 +138,7 @@ pub struct New {
     pub done: bool,
 
     /// Mark new tasks as tags.
-    /// 
+    ///
     /// Tags are color-coded to be easy to differentiate, and any tasks that
     /// (directly or indirectly) block tags will have the tag description added
     /// to their descriptions.

--- a/cli/src/subcommands/split.rs
+++ b/cli/src/subcommands/split.rs
@@ -61,4 +61,12 @@ pub struct Split {
     /// The budget of the original task will be transferred to the new tasks.
     #[clap(long, short = 'k')]
     pub keep: bool,
+
+    /// If passed with the value "true", then the new tasks will be marked as
+    /// tags. If passed with "false", then the new tasks will not be marked as
+    /// tags. If not passed, then the new tasks will be marked as tags if the
+    /// original task was marked as a tag and --keep was not passed, otherwise
+    /// they will not be marked as tags.
+    #[clap(long, short = 't')]
+    pub tag: Option<bool>,
 }

--- a/cli/src/subcommands/split_test.rs
+++ b/cli/src/subcommands/split_test.rs
@@ -140,3 +140,55 @@ fn split_keep_short() {
         }),
     );
 }
+
+#[test]
+fn split_tag_long_true() {
+    expect_parses_into(
+        "todo split 1 --into a b --tag true",
+        SubCommand::Split(Split {
+            keys: vec![ByNumber(1)],
+            into: vec!["a".to_string(), "b".to_string()],
+            tag: Some(true),
+            ..Default::default()
+        }),
+    )
+}
+
+#[test]
+fn split_tag_short_true() {
+    expect_parses_into(
+        "todo split 1 --into a b -t true",
+        SubCommand::Split(Split {
+            keys: vec![ByNumber(1)],
+            into: vec!["a".to_string(), "b".to_string()],
+            tag: Some(true),
+            ..Default::default()
+        }),
+    )
+}
+
+#[test]
+fn split_tag_long_false() {
+    expect_parses_into(
+        "todo split 1 --into a b --tag false",
+        SubCommand::Split(Split {
+            keys: vec![ByNumber(1)],
+            into: vec!["a".to_string(), "b".to_string()],
+            tag: Some(false),
+            ..Default::default()
+        }),
+    )
+}
+
+#[test]
+fn split_tag_short_false() {
+    expect_parses_into(
+        "todo split 1 --into a b -t false",
+        SubCommand::Split(Split {
+            keys: vec![ByNumber(1)],
+            into: vec!["a".to_string(), "b".to_string()],
+            tag: Some(false),
+            ..Default::default()
+        }),
+    )
+}

--- a/cli/src/subcommands/tag.rs
+++ b/cli/src/subcommands/tag.rs
@@ -1,0 +1,26 @@
+use {clap::Parser, lookup_key::Key};
+
+/// Shows, marks, or unmarks tags.
+/// 
+/// A tag is a task whose description is inserted into the description of its
+/// transitive dependencies and colored (on compatible terminals). Normally,
+/// tags are created by using the --tag flag on the 'new' command, but this
+/// subcommand can be used to turn existing tasks into tags, as well as turn
+/// tags back into tasks with the --unmark flag.
+/// 
+/// If no keys are passed, and the --unmark flag is not passed, then this
+/// subcommand will print all tags.
+#[derive(Debug, Default, PartialEq, Parser)]
+#[clap(allow_negative_numbers(true), verbatim_doc_comment)]
+pub struct Tag {
+    /// Tasks to mark as tags. If none are given and --unmark is not passed,
+    /// all existing tags are printed.
+    #[clap(required = false)]
+    pub keys: Vec<Key>,
+    /// Tasks to unmark as tags.
+    #[clap(long, short = 'u', min_values = 1, required = false)]
+    pub unmark: Vec<Key>,
+    /// If passed, print affected completed tasks.
+    #[clap(long, short = 'd')]
+    pub include_done: bool,
+}

--- a/cli/src/subcommands/tag_test.rs
+++ b/cli/src/subcommands/tag_test.rs
@@ -1,0 +1,193 @@
+use {
+    crate::{
+        testing::{expect_error, expect_parses_into},
+        SubCommand, Tag,
+    },
+    lookup_key::Key::*,
+};
+
+#[test]
+fn tag_not_enough_keys_to_unmark() {
+    expect_error("todo tag --unmark");
+    expect_error("todo tag 1 --unmark");
+    expect_error("todo tag 1 2 --unmark");
+}
+
+#[test]
+fn tag_show_all() {
+    expect_parses_into(
+        "todo tag",
+        SubCommand::Tag(Tag {
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_mark_single() {
+    expect_parses_into(
+        "todo tag 1",
+        SubCommand::Tag(Tag {
+            keys: vec![ByNumber(1)],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_mark_multiple() {
+    expect_parses_into(
+        "todo tag 1 2 3",
+        SubCommand::Tag(Tag {
+            keys: vec![ByNumber(1), ByNumber(2), ByNumber(3)],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_mark_by_name() {
+    expect_parses_into(
+        "todo tag a",
+        SubCommand::Tag(Tag {
+            keys: vec![ByName("a".to_string())],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_unmark_single_long() {
+    expect_parses_into(
+        "todo tag --unmark 1",
+        SubCommand::Tag(Tag {
+            unmark: vec![ByNumber(1)],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_unmark_multiple_long() {
+    expect_parses_into(
+        "todo tag --unmark 1 2 3",
+        SubCommand::Tag(Tag {
+            unmark: vec![ByNumber(1), ByNumber(2), ByNumber(3)],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_unmark_single_short() {
+    expect_parses_into(
+        "todo tag -u 1",
+        SubCommand::Tag(Tag {
+            unmark: vec![ByNumber(1)],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_unmark_multiple_short() {
+    expect_parses_into(
+        "todo tag -u 1 2 3",
+        SubCommand::Tag(Tag {
+            unmark: vec![ByNumber(1), ByNumber(2), ByNumber(3)],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_unmark_by_name_long() {
+    expect_parses_into(
+        "todo tag --unmark a",
+        SubCommand::Tag(Tag {
+            unmark: vec![ByName("a".to_string())],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_unmark_by_name_short() {
+    expect_parses_into(
+        "todo tag -u a",
+        SubCommand::Tag(Tag {
+            unmark: vec![ByName("a".to_string())],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_mark_and_unmark_single_long() {
+    expect_parses_into(
+        "todo tag 1 --unmark 2",
+        SubCommand::Tag(Tag {
+            keys: vec![ByNumber(1)],
+            unmark: vec![ByNumber(2)],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_include_done_long() {
+    expect_parses_into(
+        "todo tag --include-done",
+        SubCommand::Tag(Tag {
+            include_done: true,
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_include_done_short() {
+    expect_parses_into(
+        "todo tag -d",
+        SubCommand::Tag(Tag {
+            include_done: true,
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_include_done_and_unmark_single_long() {
+    expect_parses_into(
+        "todo tag --include-done --unmark 1",
+        SubCommand::Tag(Tag {
+            include_done: true,
+            unmark: vec![ByNumber(1)],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_include_done_and_unmark_single_short() {
+    expect_parses_into(
+        "todo tag -d -u 1",
+        SubCommand::Tag(Tag {
+            include_done: true,
+            unmark: vec![ByNumber(1)],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn tag_include_done_and_unmark_multiple_long() {
+    expect_parses_into(
+        "todo tag --include-done --unmark 1 2 3",
+        SubCommand::Tag(Tag {
+            include_done: true,
+            unmark: vec![ByNumber(1), ByNumber(2), ByNumber(3)],
+            ..Default::default()
+        }),
+    );
+}

--- a/model/src/task_test.rs
+++ b/model/src/task_test.rs
@@ -18,4 +18,6 @@ fn deserialize_task_with_missing_creation_time() {
     assert_eq!(task.due_date, None);
     assert_eq!(task.implicit_due_date, None);
     assert_eq!(task.budget, DurationInSeconds::default());
+    assert!(!task.tag);
+    assert_eq!(task.implicit_tags, vec![]);
 }

--- a/model/src/todo_list.rs
+++ b/model/src/todo_list.rs
@@ -688,6 +688,23 @@ impl<'ser> TodoList<'ser> {
         }
     }
 
+    pub fn set_tag(&mut self, id: TaskId, tag: bool) -> TaskSet {
+        match self.tasks.node_weight_mut(id.0) {
+            Some(task) => {
+                if task.tag == tag {
+                    return TaskSet::default();
+                }
+                task.tag = tag;
+                self.deps(id)
+                    .iter_sorted(self)
+                    .fold(TaskSet::of(id), |so_far, dep| {
+                        so_far | self.update_implicits(dep)
+                    })
+            }
+            None => TaskSet::default(),
+        }
+    }
+
     pub fn position(&self, id: TaskId) -> Option<i32> {
         self.incomplete
             .position(&id)

--- a/model/src/todo_list.rs
+++ b/model/src/todo_list.rs
@@ -47,6 +47,29 @@ impl<'ser> TodoList<'ser> {
             .min()
     }
 
+    fn calculate_implicit_tags(&self, id: TaskId) -> Vec<TaskId> {
+        self.adeps(id)
+            .iter_sorted(self)
+            .map(|adep| {
+                let mut tags = Vec::new();
+                if let Some(adep_data) = self.get(adep) {
+                    tags.extend(&adep_data.implicit_tags);
+                    if adep_data.tag && !tags.contains(&adep) {
+                        tags.push(adep);
+                    }
+                }
+                tags
+            })
+            .fold(Vec::new(), |mut so_far, adep_tags| {
+                for &tag in &adep_tags {
+                    if !so_far.contains(&tag) {
+                        so_far.push(tag);
+                    }
+                }
+                so_far
+            })
+    }
+
     fn put_in_incomplete_layer(&mut self, id: TaskId, depth: usize) -> usize {
         let pos = self.incomplete.bisect_layer(&id, depth, |&a, &b| {
             use std::cmp::Ordering;
@@ -150,12 +173,17 @@ impl<'ser> TodoList<'ser> {
     // Returns a TaskSet of affected tasks.
     pub fn update_implicits(&mut self, id: TaskId) -> TaskSet {
         let mut changed = false;
-        let (old_priority, old_due_date) = {
+        let (old_priority, old_due_date, old_tags) = {
             let task = self.get(id).unwrap();
-            (task.implicit_priority, task.implicit_due_date)
+            (
+                task.implicit_priority,
+                task.implicit_due_date,
+                task.implicit_tags.clone(),
+            )
         };
         let new_priority = self.calculate_implicit_priority(id);
         let new_due_date = self.calculate_implicit_due_date(id);
+        let new_tags = self.calculate_implicit_tags(id);
         {
             if let Some(mut task) = self.tasks.node_weight_mut(id.0) {
                 if old_priority != new_priority {
@@ -164,6 +192,10 @@ impl<'ser> TodoList<'ser> {
                 }
                 if old_due_date != new_due_date {
                     task.implicit_due_date = new_due_date;
+                    changed = true;
+                }
+                if old_tags != new_tags {
+                    task.implicit_tags = new_tags;
                     changed = true;
                 }
             }

--- a/model/src/todo_list_test/mod.rs
+++ b/model/src/todo_list_test/mod.rs
@@ -21,4 +21,5 @@ mod set_desc_test;
 mod snooze_test;
 mod stats_test;
 mod status_test;
+mod tag_test;
 mod unblock_test;

--- a/model/src/todo_list_test/tag_test.rs
+++ b/model/src/todo_list_test/tag_test.rs
@@ -1,0 +1,144 @@
+use super::*;
+
+#[test]
+fn without_tag() {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a"));
+    assert!(!list.get(a).unwrap().tag);
+}
+
+#[test]
+fn add_tag() {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    assert!(list.get(a).unwrap().tag);
+}
+
+#[test]
+fn dependency_of_tag_has_tag_as_implicit_tag() -> TestResult {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    let b = list.add("b");
+    list.block(a).on(b)?;
+    assert!(!list.get(b).unwrap().tag);
+    assert_eq!(list.get(b).unwrap().implicit_tags, vec![a]);
+    Ok(())
+}
+
+#[test]
+fn transitive_dependency_of_tag_has_tag_as_implicit_tag() -> TestResult {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    let b = list.add("b");
+    let c = list.add("c");
+    list.block(a).on(b)?;
+    list.block(b).on(c)?;
+    assert!(!list.get(c).unwrap().tag);
+    assert_eq!(list.get(c).unwrap().implicit_tags, vec![a]);
+    Ok(())
+}
+
+#[test]
+fn dependency_of_multiple_tags() -> TestResult {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    let b = list.add(NewOptions::new().desc("b").as_tag());
+    let c = list.add("c");
+    list.block(a).on(c)?;
+    list.block(b).on(c)?;
+    assert!(!list.get(c).unwrap().tag);
+    assert_eq!(list.get(c).unwrap().implicit_tags, vec![a, b]);
+    Ok(())
+}
+
+#[test]
+fn transitive_dependency_of_multiple_tags() -> TestResult {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    let b = list.add(NewOptions::new().desc("b").as_tag());
+    let c = list.add("c");
+    list.block(a).on(c)?;
+    list.block(b).on(c)?;
+    let d = list.add("d");
+    list.block(c).on(d)?;
+    assert!(!list.get(d).unwrap().tag);
+    assert_eq!(list.get(d).unwrap().implicit_tags, vec![a, b]);
+    Ok(())
+}
+
+#[test]
+fn unblock_first_tag_removes_implicit_tag_from_dep() -> TestResult {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    let b = list.add(NewOptions::new().desc("b").as_tag());
+    let c = list.add("c");
+    list.block(a).on(c)?;
+    list.block(b).on(c)?;
+    list.unblock(a).from(c)?;
+    assert_eq!(list.get(c).unwrap().implicit_tags, vec![b]);
+    Ok(())
+}
+
+#[test]
+fn unblock_second_tag_removes_implicit_tag_from_dep() -> TestResult {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    let b = list.add(NewOptions::new().desc("b").as_tag());
+    let c = list.add("c");
+    list.block(a).on(c)?;
+    list.block(b).on(c)?;
+    list.unblock(b).from(c)?;
+    assert_eq!(list.get(c).unwrap().implicit_tags, vec![a]);
+    Ok(())
+}
+
+#[test]
+fn unblock_tag_removes_implicit_tag_from_transitive_dep() -> TestResult {
+    let mut list = TodoList::default();
+    let a = list.add(NewOptions::new().desc("a").as_tag());
+    let b = list.add("b");
+    let c = list.add("c");
+    list.block(a).on(b)?;
+    list.block(b).on(c)?;
+    list.unblock(a).from(b)?;
+    assert_eq!(list.get(c).unwrap().implicit_tags, vec![]);
+    Ok(())
+}
+
+#[test]
+fn complete_task_has_tags_from_adeps() -> TestResult {
+    let mut list = TodoList::default();
+    let a = list.add("a");
+    let b = list.add(NewOptions::new().desc("b").as_tag());
+    list.block(b).on(a)?;
+    list.check(a)?;
+    assert_eq!(list.get(a).unwrap().implicit_tags, vec![b]);
+    Ok(())
+}
+
+#[test]
+fn diamond_dependency() -> TestResult {
+    let mut list = TodoList::default();
+    let a = list.add("a");
+    let b = list.add("b");
+    let c = list.add("c");
+    let d = list.add(NewOptions::new().desc("d").as_tag());
+    list.block(b).on(a)?;
+    list.block(c).on(a)?;
+    list.block(d).on(b)?;
+    list.block(d).on(c)?;
+    assert_eq!(list.get(a).unwrap().implicit_tags, vec![d]);
+    Ok(())
+}
+
+#[test]
+fn subtags() -> TestResult {
+    let mut list = TodoList::default();
+    let a = list.add("a");
+    let b = list.add(NewOptions::new().desc("b").as_tag());
+    let c = list.add(NewOptions::new().desc("c").as_tag());
+    list.block(b).on(a)?;
+    list.block(c).on(b)?;
+    assert_eq!(list.get(a).unwrap().implicit_tags, vec![c, b]);
+    Ok(())
+}

--- a/printing/src/printable_task.rs
+++ b/printing/src/printable_task.rs
@@ -9,10 +9,16 @@ use {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Status {
-    Complete,
     Incomplete,
+    Complete,
     Blocked,
     Removed,
+}
+
+impl Default for Status {
+    fn default() -> Self {
+        Status::Incomplete
+    }
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -28,6 +34,12 @@ pub enum Action {
     Punt,
     Snooze,
     Unsnooze,
+}
+
+impl Default for Action {
+    fn default() -> Self {
+        Action::None
+    }
 }
 
 impl Display for Action {
@@ -104,7 +116,7 @@ impl<T> Plicit<T> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct PrintableTask<'a> {
     pub desc: &'a str,
     pub number: i32,
@@ -118,6 +130,8 @@ pub struct PrintableTask<'a> {
     pub start_date: Option<DateTime<Utc>>,
     pub deps_stats: (usize, usize),
     pub adeps_stats: (usize, usize),
+    pub is_explicit_tag: bool,
+    pub implicit_tags: Vec<&'a str>,
 }
 
 impl<'a> PrintableTask<'a> {
@@ -126,15 +140,7 @@ impl<'a> PrintableTask<'a> {
             desc,
             number,
             status,
-            action: Action::None,
-            log_date: None,
-            priority: None,
-            due_date: None,
-            punctuality: None,
-            budget: None,
-            start_date: None,
-            deps_stats: (0, 0),
-            adeps_stats: (0, 0),
+            ..Default::default()
         }
     }
 
@@ -180,6 +186,16 @@ impl<'a> PrintableTask<'a> {
 
     pub fn adeps_stats(mut self, immediate: usize, total: usize) -> Self {
         self.adeps_stats = (immediate, total);
+        self
+    }
+
+    pub fn as_tag(mut self) -> Self {
+        self.is_explicit_tag = true;
+        self
+    }
+
+    pub fn tag(mut self, tag: &'a str) -> Self {
+        self.implicit_tags.push(tag);
         self
     }
 }

--- a/printing/src/printable_task_test.rs
+++ b/printing/src/printable_task_test.rs
@@ -557,3 +557,64 @@ fn show_punctuality_completed_minutes_late() {
         )
     );
 }
+
+#[test]
+fn show_implicit_tags() {
+    let fmt =
+        print_task(&PrintableTask::new("a", 1, Incomplete).tag("x").tag("y"));
+    assert_eq!(
+        fmt,
+        concat!(
+            "      \u{1b}[33m1)\u{1b}[0m ",
+            "\u{1b}[2;3;34mx\u{1b}[0m ",
+            "\u{1b}[2;3;34my\u{1b}[0m ",
+            "a\n"
+        )
+    );
+}
+
+#[test]
+fn explicit_tag() {
+    let fmt = print_task(&PrintableTask::new("a", 1, Incomplete).as_tag());
+    assert_eq!(fmt, "      \u{1b}[33m1)\u{1b}[0m \u{1b}[2;34ma\u{1b}[0m\n",);
+}
+
+#[test]
+fn explicit_tag_with_implicit_tags() {
+    let fmt = print_task(
+        &PrintableTask::new("a", 1, Incomplete)
+            .tag("x")
+            .tag("y")
+            .as_tag(),
+    );
+    assert_eq!(
+        fmt,
+        concat!(
+            "      \u{1b}[33m1)\u{1b}[0m ",
+            "\u{1b}[2;3;34mx\u{1b}[0m ",
+            "\u{1b}[2;3;34my\u{1b}[0m ",
+            "\u{1b}[2;34ma\u{1b}[0m\n",
+        )
+    );
+}
+
+#[test]
+fn explicit_tag_with_implicit_tags_and_punctuality() {
+    let fmt = print_task(
+        &PrintableTask::new("a", 0, Complete)
+            .punctuality(chrono::Duration::days(1))
+            .tag("x")
+            .tag("y")
+            .as_tag(),
+    );
+    assert_eq!(
+        fmt,
+        concat!(
+            "      \u{1b}[32m0)\u{1b}[0m ",
+            "\u{1b}[1;31mDone 1 day late\u{1b}[0m ",
+            "\u{1b}[2;3;34mx\u{1b}[0m ",
+            "\u{1b}[2;3;34my\u{1b}[0m ",
+            "\u{1b}[2;34ma\u{1b}[0m\n",
+        )
+    );
+}

--- a/printing/src/printable_task_test.rs
+++ b/printing/src/printable_task_test.rs
@@ -566,8 +566,8 @@ fn show_implicit_tags() {
         fmt,
         concat!(
             "      \u{1b}[33m1)\u{1b}[0m ",
-            "\u{1b}[2;3;34mx\u{1b}[0m ",
-            "\u{1b}[2;3;34my\u{1b}[0m ",
+            "\u{1b}[3;4;38;5;11mx\u{1b}[0m ",
+            "\u{1b}[3;4;38;5;15my\u{1b}[0m ",
             "a\n"
         )
     );
@@ -576,7 +576,7 @@ fn show_implicit_tags() {
 #[test]
 fn explicit_tag() {
     let fmt = print_task(&PrintableTask::new("a", 1, Incomplete).as_tag());
-    assert_eq!(fmt, "      \u{1b}[33m1)\u{1b}[0m \u{1b}[2;34ma\u{1b}[0m\n",);
+    assert_eq!(fmt, "      \u{1b}[33m1)\u{1b}[0m \u{1b}[4;38;5;2ma\u{1b}[0m\n",);
 }
 
 #[test]
@@ -591,9 +591,9 @@ fn explicit_tag_with_implicit_tags() {
         fmt,
         concat!(
             "      \u{1b}[33m1)\u{1b}[0m ",
-            "\u{1b}[2;3;34mx\u{1b}[0m ",
-            "\u{1b}[2;3;34my\u{1b}[0m ",
-            "\u{1b}[2;34ma\u{1b}[0m\n",
+            "\u{1b}[3;4;38;5;11mx\u{1b}[0m ",
+            "\u{1b}[3;4;38;5;15my\u{1b}[0m ",
+            "\u{1b}[4;38;5;2ma\u{1b}[0m\n",
         )
     );
 }
@@ -612,9 +612,9 @@ fn explicit_tag_with_implicit_tags_and_punctuality() {
         concat!(
             "      \u{1b}[32m0)\u{1b}[0m ",
             "\u{1b}[1;31mDone 1 day late\u{1b}[0m ",
-            "\u{1b}[2;3;34mx\u{1b}[0m ",
-            "\u{1b}[2;3;34my\u{1b}[0m ",
-            "\u{1b}[2;34ma\u{1b}[0m\n",
+            "\u{1b}[3;4;38;5;11mx\u{1b}[0m ",
+            "\u{1b}[3;4;38;5;15my\u{1b}[0m ",
+            "\u{1b}[4;38;5;2ma\u{1b}[0m\n",
         )
     );
 }

--- a/printing/src/simple_todo_printer.rs
+++ b/printing/src/simple_todo_printer.rs
@@ -179,15 +179,24 @@ fn fmt_unlocks(unlockable: usize, total: usize, out: &mut String) {
 
 // Allocate a color for a tag with the given name. The color is
 // deterministically allocated based on the hash of the tag name, from a pool of
-// neutral colors (light and dark variants of blue, cyan, and purple).
+// neutral colors (excluding black), and underlined to help distinguish tags
+// from task descriptions.
 fn allocate_tag_color(tag_name: &str) -> Style {
-    let neutral_colors: [Style; 6] = [
-        Color::Blue.normal(),
-        Color::Cyan.normal(),
-        Color::Purple.normal(),
-        Color::Blue.dimmed(),
-        Color::Cyan.dimmed(),
-        Color::Purple.dimmed(),
+    let neutral_colors = [
+        Color::Fixed(1).normal(),
+        Color::Fixed(2).normal(),
+        Color::Fixed(3).normal(),
+        Color::Fixed(4).normal(),
+        Color::Fixed(5).normal(),
+        Color::Fixed(6).normal(),
+        Color::Fixed(7).normal(),
+        Color::Fixed(9).normal(),
+        Color::Fixed(10).normal(),
+        Color::Fixed(11).normal(),
+        Color::Fixed(12).normal(),
+        Color::Fixed(13).normal(),
+        Color::Fixed(14).normal(),
+        Color::Fixed(15).normal(),
     ];
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
@@ -195,7 +204,7 @@ fn allocate_tag_color(tag_name: &str) -> Style {
     tag_name.hash(&mut hasher);
     let hash: usize = hasher.finish() as usize;
     let index = hash % neutral_colors.len();
-    neutral_colors[index]
+    neutral_colors[index].underline()
 }
 
 fn fmt_tag(tag: Plicit<&str>, out: &mut String) {

--- a/printing/src/testing_test.rs
+++ b/printing/src/testing_test.rs
@@ -286,3 +286,47 @@ fn fail_validation_on_incorrect_start_date() {
         )
         .end()
 }
+
+#[test]
+#[should_panic(expected = "Missing tags")]
+fn fail_validation_on_missing_tag() {
+    let mut printer = FakePrinter::default();
+    printer.print_task(&PrintableTask::new("a", 1, Incomplete));
+    printer
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).tag("x"))
+        .end()
+}
+
+#[test]
+#[should_panic(expected = "Extraneous tags")]
+fn fail_validation_on_extraneous_tag() {
+    let mut printer = FakePrinter::default();
+    printer.print_task(&PrintableTask::new("a", 1, Incomplete).tag("x"));
+    printer
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .end()
+}
+
+#[test]
+#[should_panic(expected = "Task is unexpectedly not a tag")]
+fn fail_validation_task_is_tag() {
+    let mut printer = FakePrinter::default();
+    printer.print_task(&PrintableTask::new("a", 1, Incomplete));
+    printer
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).as_tag())
+        .end()
+}
+
+#[test]
+#[should_panic(expected = "Task is unexpectedly a tag")]
+fn fail_validation_task_is_not_tag() {
+    let mut printer = FakePrinter::default();
+    printer.print_task(&PrintableTask::new("a", 1, Incomplete).as_tag());
+    printer
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .end()
+}


### PR DESCRIPTION
This integrates the ability to mark a task as a "tag".

A tag's description will be colorized and inserted before the description of all of its transitive dependencies.

The main way to create a tag is with `todo new`:

```
>>todo new work home --tag
1) work
2) home

>>todo new "wash the dishes" -b home
2) [home] wash the dishes
```

You can also use `todo tag` to view all tags, mark a task as a tag, or unmark a tag so it becomes a normal task.