### PR TITLE
Only save the list if data are mutated.

### DIFF
--- a/app/src/block_test.rs
+++ b/app/src/block_test.rs
@@ -11,6 +11,7 @@ fn block_one_on_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a b");
     fix.test("todo block 1 --on 2")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
@@ -22,6 +23,7 @@ fn block_by_name() {
     let mut fix = Fixture::default();
     fix.test("todo new a b");
     fix.test("todo block a --on b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
@@ -33,6 +35,7 @@ fn block_one_on_three() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d");
     fix.test("todo block 1 --on 2 3 4")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Incomplete))
@@ -46,6 +49,7 @@ fn block_three_on_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d");
     fix.test("todo block 1 2 3 --on 4")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("d", 1, Incomplete))
         .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
@@ -60,6 +64,7 @@ fn block_on_complete_task() {
     fix.test("todo new a b c");
     fix.test("todo check 1 2");
     fix.test("todo block 1 --on -1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -1, Complete))
         .printed_task(&PrintableTask::new("c", 1, Incomplete).action(Lock))
@@ -71,6 +76,7 @@ fn block_multiple_on_following_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d");
     fix.test("todo block 1 2 --on 3")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("c", 1, Incomplete))
         .printed_task(&PrintableTask::new("a", 3, Blocked).action(Lock))
@@ -83,6 +89,7 @@ fn cannot_block_on_self() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo block 1 --on 1")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotBlockBecauseWouldCauseCycle {
             cannot_block: BriefPrintableTask::new(1, Incomplete),
@@ -97,6 +104,7 @@ fn block_updates_implicit_priority_of_deps() {
     fix.test("todo new a b --chain");
     fix.test("todo new c --priority 1");
     fix.test("todo block c --on b")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
@@ -118,6 +126,7 @@ fn block_does_not_print_priority_updates_for_unaffected_deps() {
     fix.test("todo new a b --chain --priority 1");
     fix.test("todo new c --priority 1");
     fix.test("todo block c --on b")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 2, Blocked).priority(Explicit(1)),
@@ -137,6 +146,7 @@ fn block_excludes_complete_affected_tasks() {
     fix.test("todo new c --priority 1");
     fix.test("todo check a");
     fix.test("todo block c --on b")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete).priority(Implicit(1)),
@@ -156,6 +166,7 @@ fn block_include_done() {
     fix.test("todo new c --priority 1");
     fix.test("todo check a");
     fix.test("todo block c --on b -d")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 0, Complete).priority(Implicit(1)),
@@ -176,6 +187,7 @@ fn block_complete_task_on_preceding_complete_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --done");
     fix.test("todo block b --on a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -1, Complete))
         .printed_task(&PrintableTask::new("b", 0, Complete).action(Lock))
@@ -187,6 +199,7 @@ fn block_complete_task_on_distantly_preceding_complete_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e --done");
     fix.test("todo block e --on a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -4, Complete))
         .printed_task(&PrintableTask::new("e", 0, Complete).action(Lock))
@@ -198,6 +211,7 @@ fn block_complete_task_on_later_complete_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --done");
     fix.test("todo block a --on b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", -1, Complete))
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Lock))
@@ -209,6 +223,7 @@ fn block_complete_task_on_distant_later_complete_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e --done");
     fix.test("todo block a --on e")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("e", -1, Complete))
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Lock))
@@ -220,9 +235,24 @@ fn block_multiple_complete_tasks_on_later_complete_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d --done");
     fix.test("todo block a b --on d")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("d", -2, Complete))
         .printed_task(&PrintableTask::new("a", -1, Complete).action(Lock))
         .printed_task(&PrintableTask::new("b", 0, Complete).action(Lock))
+        .end();
+}
+
+#[test]
+#[ignore = "This is an optimization that can be done later"]
+fn redundant_block_does_not_modify() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b --chain");
+    fix.test("todo block b --on a");
+    fix.test("todo block b --on a")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 0, Incomplete))
+        .printed_task(&PrintableTask::new("b", 1, Blocked).action(Lock))
         .end();
 }

--- a/app/src/budget_test.rs
+++ b/app/src/budget_test.rs
@@ -16,6 +16,7 @@ fn budget_one_task() {
     let in_2_days = ymdhms(2021, 05, 01, 23, 59, 59);
     fix.test("todo new a --due 2 days");
     fix.test("todo budget a --is 1 day")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -31,6 +32,7 @@ fn budget_multiple_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e");
     fix.test("todo budget a c e --is 2 days")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -56,6 +58,7 @@ fn budget_chain_alters_due_dates() {
     fix.clock.now = ymdhms(2021, 04, 29, 12, 00, 00);
     fix.test("todo new a b c d e --chain --due today");
     fix.test("todo budget a b c d e --is 1 hour")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -96,6 +99,7 @@ fn budget_shows_affected_tasks() {
     fix.clock.now = ymdhms(2021, 04, 29, 15, 00, 00);
     fix.test("todo new a b c --chain --due 5 hours");
     fix.test("todo budget c --is 2 hours")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -121,6 +125,7 @@ fn budget_does_not_show_unaffected_tasks() {
     fix.test("todo new a b c --chain --due 5 hours");
     fix.test("todo due a --in 1 hour");
     fix.test("todo budget c --is 2 hours")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 2, Blocked)
@@ -140,6 +145,7 @@ fn invalid_budget() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo budget a --is blah")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotParseDuration {
             cannot_parse: "blah".to_string(),
@@ -152,6 +158,7 @@ fn too_long_budget() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo budget a --is 200 years")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::DurationIsTooLong {
             duration: 6311520000,
@@ -167,6 +174,7 @@ fn budget_does_not_include_complete_affected_deps() {
     fix.test("todo new a b c --chain --due today");
     fix.test("todo check a");
     fix.test("todo budget c --is 1 hour")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete)
@@ -188,6 +196,7 @@ fn budget_include_complete_affected_deps() {
     fix.test("todo new a b c --chain --due today");
     fix.test("todo check a");
     fix.test("todo budget c --is 1 hour -d")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 0, Complete)
@@ -211,6 +220,7 @@ fn budget_of_zero() {
     let mut fix = Fixture::default();
     fix.test("todo new a --budget 1 hour");
     fix.test("todo budget a --is 0")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
         .end();

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -8,7 +8,11 @@ use {
     std::collections::HashMap,
 };
 
-pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Chain) {
+pub fn run(
+    list: &mut TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: &Chain,
+) -> bool {
     let tasks = cmd
         .keys
         .iter()
@@ -17,6 +21,7 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Chain) {
     let include_done =
         should_include_done(cmd.include_done, list, tasks.iter().copied());
     let mut actions = HashMap::new();
+    let mut mutated = false;
     use itertools::Itertools;
     tasks
         .iter()
@@ -25,6 +30,7 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Chain) {
         .fold(TaskSet::default(), |so_far, (a, b)| {
             match list.block(b).on(a) {
                 Ok(affected) => {
+                    mutated = true;
                     actions.insert(b, Action::Lock);
                     so_far | affected
                 }
@@ -48,4 +54,5 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Chain) {
                     .action(*actions.get(&id).unwrap_or(&Action::None)),
             );
         });
+    mutated
 }

--- a/app/src/chain_test.rs
+++ b/app/src/chain_test.rs
@@ -10,7 +10,7 @@ use {
 fn chain_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
-    fix.test("todo chain a").validate().end();
+    fix.test("todo chain a").modified(false).validate().end();
 }
 
 #[test]
@@ -18,6 +18,7 @@ fn chain_three() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e");
     fix.test("todo chain a b c")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 4, Blocked).action(Lock))
@@ -30,6 +31,7 @@ fn chain_would_cause_cycle() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");
     fix.test("todo chain b a")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotBlockBecauseWouldCauseCycle {
             cannot_block: BriefPrintableTask::new(1, Incomplete),
@@ -44,6 +46,7 @@ fn chain_shows_affected_deps() {
     fix.test("todo new a b --chain");
     fix.test("todo new c --priority 1");
     fix.test("todo chain b c")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
@@ -66,6 +69,7 @@ fn chain_excludes_complete_affected_deps() {
     fix.test("todo new c --priority 1");
     fix.test("todo check a");
     fix.test("todo chain b c")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete).priority(Implicit(1)),
@@ -83,6 +87,7 @@ fn chain_by_range() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo chain 1..3")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(Lock))
@@ -95,6 +100,7 @@ fn chain_ambiguous_key() {
     let mut fix = Fixture::default();
     fix.test("todo new a a a");
     fix.test("todo chain a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))

--- a/app/src/check_test.rs
+++ b/app/src/check_test.rs
@@ -11,6 +11,7 @@ fn check_one_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo check 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
         .end();
@@ -21,6 +22,7 @@ fn check_by_name() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo check b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 0, Complete).action(Check))
         .end();
@@ -32,6 +34,7 @@ fn check_task_with_incomplete_dependencies() {
     fix.test("todo new a b");
     fix.test("todo block 2 --on 1");
     fix.test("todo check 2")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotCheckBecauseBlocked {
             cannot_check: BriefPrintableTask::new(2, Blocked),
@@ -46,6 +49,7 @@ fn cannot_check_blocked_task() {
     fix.test("todo new a b");
     fix.test("todo block 1 --on 2");
     fix.test("todo check 2")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotCheckBecauseBlocked {
             cannot_check: BriefPrintableTask::new(2, Blocked),
@@ -60,11 +64,13 @@ fn check_newly_unblocked_task() {
     fix.test("todo new a b");
     fix.test("todo block 1 --on 2");
     fix.test("todo check 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 0, Complete).action(Check))
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Unlock))
         .end();
     fix.test("todo check 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
         .end();
@@ -76,12 +82,14 @@ fn check_newly_unblocked_task_with_multiple_dependencies() {
     fix.test("todo new a b c");
     fix.test("todo block 1 --on 2 3");
     fix.test("todo check 1 2")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", -1, Complete).action(Check))
         .printed_task(&PrintableTask::new("c", 0, Complete).action(Check))
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Unlock))
         .end();
     fix.test("todo check 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
         .end();
@@ -94,16 +102,19 @@ fn check_newly_unblocked_task_with_chained_dependencies() {
     fix.test("todo block 3 --on 2");
     fix.test("todo block 2 --on 1");
     fix.test("todo check 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
         .printed_task(&PrintableTask::new("b", 1, Incomplete).action(Unlock))
         .end();
     fix.test("todo check 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 0, Complete).action(Check))
         .printed_task(&PrintableTask::new("c", 1, Incomplete).action(Unlock))
         .end();
     fix.test("todo check 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("c", 0, Complete).action(Check))
         .end();
@@ -115,6 +126,7 @@ fn check_does_not_show_adeps_that_are_not_unlocked() {
     fix.test("todo new a");
     fix.test("todo new b c -p 1 --chain");
     fix.test("todo check 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
         .printed_task(&PrintableTask::new("b", 1, Incomplete).action(Unlock))
@@ -128,6 +140,7 @@ fn check_same_task_twice_in_one_command() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo check 1 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
         .end();
@@ -139,6 +152,7 @@ fn check_complete_task() {
     fix.test("todo new a");
     fix.test("todo check a");
     fix.test("todo check a")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::CannotCheckBecauseAlreadyComplete {
             cannot_check: BriefPrintableTask::new(0, Complete),
@@ -151,6 +165,7 @@ fn force_check_incomplete_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo check a --force")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
         .end();
@@ -161,6 +176,7 @@ fn force_check_blocked_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");
     fix.test("todo check b --force")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -1, Complete).action(Check))
         .printed_task(&PrintableTask::new("b", 0, Complete).action(Check))
@@ -172,6 +188,7 @@ fn force_check_transitively_blocked_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo check c --force")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -2, Complete).action(Check))
         .printed_task(&PrintableTask::new("b", -1, Complete).action(Check))
@@ -186,6 +203,7 @@ fn force_check_task_with_complete_deps() {
     fix.test("todo new c -p a b");
     fix.test("todo check a");
     fix.test("todo check c --force")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", -1, Complete).action(Check))
         .printed_task(&PrintableTask::new("c", 0, Complete).action(Check))
@@ -198,6 +216,7 @@ fn force_check_complete_task() {
     fix.test("todo new a");
     fix.test("todo check a");
     fix.test("todo check a --force")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::CannotCheckBecauseAlreadyComplete {
             cannot_check: BriefPrintableTask::new(0, Complete),
@@ -210,6 +229,7 @@ fn check_blocking_chain() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo check a b c")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -2, Complete).action(Check))
         .printed_task(&PrintableTask::new("b", -1, Complete).action(Check))

--- a/app/src/due_test.rs
+++ b/app/src/due_test.rs
@@ -14,6 +14,7 @@ fn show_tasks_with_due_date() {
     fix.test("todo new a b c --due 1 day");
     fix.test("todo new d e f");
     fix.test("todo due")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -41,6 +42,7 @@ fn show_tasks_with_due_date_includes_blocked() {
     fix.test("todo new c -p b --due 2 days");
     fix.test("todo new d e f");
     fix.test("todo due")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -66,6 +68,7 @@ fn show_tasks_with_due_date_excludes_complete() {
     fix.test("todo new d e f");
     fix.test("todo check a");
     fix.test("todo due")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete)
@@ -88,6 +91,7 @@ fn show_tasks_with_due_date_include_done() {
     fix.test("todo new d e f");
     fix.test("todo check a");
     fix.test("todo due --include-done")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 0, Complete)
@@ -115,6 +119,7 @@ fn show_tasks_with_due_date_earlier_than_given_date() {
     fix.test("todo new d e f");
     fix.test("todo new g --due 6 hours");
     fix.test("todo due --in 1 day")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -139,6 +144,7 @@ fn show_tasks_with_due_date_earlier_than_given_date_include_done() {
     fix.test("todo new g --due 6 hours");
     fix.test("todo check g");
     fix.test("todo due --in 1 day -d")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("g", 0, Complete)
@@ -161,6 +167,7 @@ fn show_source_of_implicit_due_date() {
     fix.test("todo new c -p b --due 2 days");
     fix.test("todo new d e f --due today");
     fix.test("todo due a")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 4, Incomplete)
@@ -185,6 +192,7 @@ fn set_due_date() {
     fix.test("todo new c -p b --due 2 days");
     fix.test("todo new d e f");
     fix.test("todo due d e --on thursday")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("d", 2, Incomplete)
@@ -205,6 +213,7 @@ fn set_due_date_excludes_complete_tasks() {
     fix.test("todo new a b --chain");
     fix.test("todo check a");
     fix.test("todo due b --on thursday")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete)
@@ -222,6 +231,7 @@ fn set_due_date_include_done() {
     fix.test("todo new a b --chain");
     fix.test("todo check a");
     fix.test("todo due b --on thursday --include-done")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 0, Complete)
@@ -244,6 +254,7 @@ fn set_due_date_prints_affected_tasks() {
     fix.test("todo new c -p b --due 2 days");
     fix.test("todo new d e f");
     fix.test("todo due c --in 1 hour")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -266,6 +277,7 @@ fn reset_due_date() {
     fix.test("todo new c -p b --due 2 days");
     fix.test("todo new d e f");
     fix.test("todo due c --none")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 5, Blocked))
         .printed_task(&PrintableTask::new("c", 6, Blocked))
@@ -279,6 +291,7 @@ fn show_tasks_without_due_dates() {
     fix.test("todo new d e f --due tomorrow -p a b c");
     fix.test("todo new g h i --chain");
     fix.test("todo due --none")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("g", 4, Incomplete))
         .printed_task(&PrintableTask::new("h", 8, Blocked))
@@ -293,6 +306,7 @@ fn show_tasks_without_due_date_excludes_complete() {
     fix.test("todo new d e f --chain");
     fix.test("todo check d");
     fix.test("todo due --none")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("e", 4, Incomplete))
         .printed_task(&PrintableTask::new("f", 5, Blocked))
@@ -306,6 +320,7 @@ fn show_tasks_without_due_date_include_done() {
     fix.test("todo new d e f --chain");
     fix.test("todo check d");
     fix.test("todo due --none -d")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("d", 0, Complete))
         .printed_task(&PrintableTask::new("e", 4, Incomplete))
@@ -318,6 +333,7 @@ fn cannot_use_due_and_none_flags_at_the_same_time() {
     let mut fix = Fixture::default();
     fix.clock.now = ymdhms(2021, 04, 13, 18, 00, 00);
     fix.test("todo due --in 1 day --none")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::ConflictingArgs((
             "due".to_string(),

--- a/app/src/edit_test.rs
+++ b/app/src/edit_test.rs
@@ -9,6 +9,7 @@ fn edit_one_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo edit 1 --desc b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .end();
@@ -19,6 +20,7 @@ fn edit_multiple_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo edit 1 2 3 --desc d")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("d", 1, Incomplete))
         .printed_task(&PrintableTask::new("d", 2, Incomplete))
@@ -32,6 +34,7 @@ fn edit_with_text_editor_happy_path() {
     fix.test("todo new a");
     fix.text_editor = FakeTextEditor::user_will_enter("1) b\n");
     fix.test("todo edit 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .end();
@@ -44,6 +47,7 @@ fn edit_with_text_editor_long_desc_later_task() {
     fix.test("todo new a b c");
     fix.text_editor = FakeTextEditor::user_will_enter("3) this is serious\n");
     fix.test("todo edit 3")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("this is serious", 3, Incomplete))
         .end();
@@ -56,6 +60,7 @@ fn edit_multiple_tasks_with_text_editor() {
     fix.test("todo new a b c");
     fix.text_editor = FakeTextEditor::user_will_enter("1) d\n2) e\n3) f\n");
     fix.test("todo edit 1 2 3")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("d", 1, Incomplete))
         .printed_task(&PrintableTask::new("e", 2, Incomplete))
@@ -70,6 +75,7 @@ fn edit_with_text_editor_invalid_task_number() {
     fix.test("todo new a");
     fix.text_editor = FakeTextEditor::user_will_enter("2) b");
     fix.test("todo edit 1")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotEditBecauseNoTaskWithNumber {
             requested: 2,
@@ -98,6 +104,7 @@ fn edit_with_text_editor_empty_description() {
     fix.test("todo new a");
     fix.text_editor = FakeTextEditor::user_will_enter("1)");
     fix.test("todo edit 1")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotEditBecauseInvalidLine {
             malformed_line: "1)".to_string(),
@@ -112,6 +119,7 @@ fn edit_with_text_editor_remove_delimiter() {
     fix.test("todo new a");
     fix.text_editor = FakeTextEditor::user_will_enter("1 b");
     fix.test("todo edit 1")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotEditBecauseInvalidLine {
             malformed_line: "1 b".to_string(),
@@ -125,6 +133,7 @@ fn edit_with_text_editor_text_editor_fails() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo edit 1")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::FailedToUseTextEditor)
         .end();

--- a/app/src/find.rs
+++ b/app/src/find.rs
@@ -26,10 +26,14 @@ fn find_with_tag(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Find) {
         });
 }
 
-pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Find) {
+pub fn run(
+    list: &TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: &Find,
+) -> bool {
     if cmd.tag {
         find_with_tag(list, printer, cmd);
-        return;
+        return false;
     }
     list.all_tasks()
         .filter(|&id| {
@@ -42,5 +46,6 @@ pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Find) {
         .filter(|&id| {
             cmd.include_done || list.status(id) != Some(TaskStatus::Complete)
         })
-        .for_each(|id| printer.print_task(&format_task(list, id)))
+        .for_each(|id| printer.print_task(&format_task(list, id)));
+    false
 }

--- a/app/src/find_test.rs
+++ b/app/src/find_test.rs
@@ -8,6 +8,7 @@ fn find_with_exact_match() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo find b")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("b", 2, Incomplete))
         .end();
@@ -18,6 +19,7 @@ fn find_with_substring_match() {
     let mut fix = Fixture::default();
     fix.test("todo new aaa aba aca");
     fix.test("todo find b")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("aba", 2, Incomplete))
         .end();
@@ -28,6 +30,7 @@ fn find_with_multiple_matches() {
     let mut fix = Fixture::default();
     fix.test("todo new aaa aba aca");
     fix.test("todo find a")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("aaa", 1, Incomplete))
         .printed_task(&PrintableTask::new("aba", 2, Incomplete))
@@ -40,7 +43,7 @@ fn find_excludes_complete_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new aaa aba aca");
     fix.test("todo check 2");
-    fix.test("todo find b").validate().end();
+    fix.test("todo find b").modified(false).validate().end();
 }
 
 #[test]
@@ -49,6 +52,7 @@ fn find_includes_complete_tasks() {
     fix.test("todo new aaa aba aca");
     fix.test("todo check 2");
     fix.test("todo find b -d")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("aba", 0, Complete))
         .end();
@@ -59,6 +63,7 @@ fn find_includes_blocked_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new aaa aba aca --chain");
     fix.test("todo find b")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("aba", 2, Blocked))
         .end();
@@ -69,6 +74,7 @@ fn find_case_insensitive() {
     let mut fix = Fixture::default();
     fix.test("todo new AAA aaa");
     fix.test("todo find aa")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("AAA", 1, Incomplete))
         .printed_task(&PrintableTask::new("aaa", 2, Incomplete))
@@ -82,6 +88,7 @@ fn find_includes_matches_with_tag() {
     fix.test("todo new g -p a b c --tag");
     // Because a, b, and c are tagged with 'g', they show up in 'find' results.
     fix.test("todo find g -t")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 4, Incomplete).tag("g"))
         .printed_task(&PrintableTask::new("b", 5, Incomplete).tag("g"))
@@ -98,6 +105,7 @@ fn find_includes_matches_with_tag_excludes_complete() {
     // Although a, b, and c are tagged with 'g', they are complete, so they do
     // not show up in 'find' results by default.
     fix.test("todo find g -t")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("g", 1, Incomplete).as_tag())
         .end();
@@ -111,6 +119,7 @@ fn find_includes_matches_with_tag_include_complete() {
     // Since the '-d' flag is used, a, b, and c show up even though they are
     // complete.
     fix.test("todo find g -d -t")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", -5, Complete).tag("g"))
         .printed_task(&PrintableTask::new("b", -4, Complete).tag("g"))

--- a/app/src/get.rs
+++ b/app/src/get.rs
@@ -5,7 +5,7 @@ use {
     printing::{Action, TodoPrinter},
 };
 
-pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Get) {
+pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Get) -> bool {
     let requested_tasks = lookup_tasks(list, &cmd.keys);
     let include_done = should_include_done(
         cmd.include_done,
@@ -33,4 +33,5 @@ pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Get) {
             },
         ))
     });
+    false
 }

--- a/app/src/get_test.rs
+++ b/app/src/get_test.rs
@@ -8,6 +8,7 @@ fn get_incomplete_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo get 2")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Select))
         .end();
@@ -19,6 +20,7 @@ fn get_complete_task() {
     fix.test("todo new a b c");
     fix.test("todo check 1 2 3");
     fix.test("todo get -2")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", -2, Complete).action(Select))
         .end();
@@ -29,6 +31,7 @@ fn get_multiple_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e");
     fix.test("todo get 2 3 4")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Select))
         .printed_task(&PrintableTask::new("c", 3, Incomplete).action(Select))
@@ -42,6 +45,7 @@ fn get_excludes_completed_deps() {
     fix.test("todo new a b --chain");
     fix.test("todo check a");
     fix.test("todo get b")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete).action(Select))
         .end();
@@ -53,6 +57,7 @@ fn get_include_done() {
     fix.test("todo new a b --chain");
     fix.test("todo check a");
     fix.test("todo get b -d")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete))
         .printed_task(&PrintableTask::new("b", 1, Incomplete).action(Select))
@@ -65,6 +70,7 @@ fn get_shows_blocking_tasks() {
     fix.test("todo new a b");
     fix.test("todo block 2 --on 1");
     fix.test("todo get 2")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
@@ -77,6 +83,7 @@ fn get_shows_blocked_tasks() {
     fix.test("todo new a b");
     fix.test("todo block 2 --on 1");
     fix.test("todo get 1")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
         .printed_task(&PrintableTask::new("b", 2, Blocked))
@@ -88,6 +95,7 @@ fn get_shows_transitive_deps_and_adeps() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e --chain");
     fix.test("todo get 3")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Blocked))
@@ -102,6 +110,7 @@ fn get_by_name_multiple_matches() {
     let mut fix = Fixture::default();
     fix.test("todo new bob frank bob");
     fix.test("todo get bob")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("bob", 1, Incomplete).action(Select))
         .printed_task(&PrintableTask::new("bob", 3, Incomplete).action(Select))
@@ -113,6 +122,7 @@ fn get_no_context_single_task_by_name() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo get a -n")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
         .end();
@@ -123,6 +133,7 @@ fn get_no_context_multiple_tasks_by_name() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo get a b -n")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
@@ -135,6 +146,7 @@ fn get_no_context_single_completed_task() {
     fix.test("todo new a b c --chain");
     fix.test("todo check a b c");
     fix.test("todo get a -n")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", -2, Complete).action(Select))
         .end();
@@ -146,6 +158,7 @@ fn get_no_context_multiple_completed_tasks() {
     fix.test("todo new a b c --chain");
     fix.test("todo check a b c");
     fix.test("todo get a b -n")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", -2, Complete).action(Select))
         .printed_task(&PrintableTask::new("b", -1, Complete).action(Select))
@@ -157,6 +170,7 @@ fn get_no_context_blocked_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo get c -n")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("c", 3, Blocked).action(Select))
         .end();
@@ -168,6 +182,7 @@ fn get_no_context_complete_and_incomplete_match() {
     fix.test("todo new a b a --chain");
     fix.test("todo check 1");
     fix.test("todo get a -n")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Select))
         .printed_task(&PrintableTask::new("a", 2, Blocked).action(Select))

--- a/app/src/log.rs
+++ b/app/src/log.rs
@@ -5,7 +5,7 @@ use {
     printing::{LogDate, TodoPrinter},
 };
 
-pub fn run(list: &TodoList, printer: &mut impl TodoPrinter) {
+pub fn run(list: &TodoList, printer: &mut impl TodoPrinter) -> bool {
     let mut most_recent_shown = None;
     list.complete_tasks().for_each(|id| {
         let mut formatted_task = format_task(list, id);
@@ -30,4 +30,5 @@ pub fn run(list: &TodoList, printer: &mut impl TodoPrinter) {
             });
         printer.print_task(&formatted_task);
     });
+    false
 }

--- a/app/src/log_test.rs
+++ b/app/src/log_test.rs
@@ -9,7 +9,7 @@ use {
 #[test]
 fn log_with_no_tasks_completed() {
     let mut fix = Fixture::default();
-    fix.test("todo log").validate().end();
+    fix.test("todo log").modified(false).validate().end();
 }
 
 #[test]
@@ -19,6 +19,7 @@ fn log_after_single_task_completed() {
     fix.test("todo new a b c");
     fix.test("todo check 2");
     fix.test("todo log")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 0, Complete)
@@ -34,6 +35,7 @@ fn log_after_multiple_tasks_completed() {
     fix.test("todo new a b c");
     fix.test("todo check 1 3");
     fix.test("todo log")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("c", 0, Complete)
@@ -62,6 +64,7 @@ fn log_shows_date_when_it_changes() {
         .with_timezone(&Utc);
     fix.test("todo check c d");
     fix.test("todo log")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("d", 0, Complete)

--- a/app/src/merge.rs
+++ b/app/src/merge.rs
@@ -12,7 +12,7 @@ pub fn run(
     printer: &mut impl TodoPrinter,
     now: DateTime<Utc>,
     cmd: &Merge,
-) {
+) -> bool {
     let tasks_to_merge = lookup_tasks(list, &cmd.keys);
     let deps = tasks_to_merge
         .iter_unsorted()
@@ -49,7 +49,7 @@ pub fn run(
             adeps_of: format_tasks_brief(list, &adeps_of),
             deps_of: format_tasks_brief(list, &deps_of),
         });
-        return;
+        return false;
     }
     let priority = tasks_to_merge
         .iter_unsorted()
@@ -108,4 +108,5 @@ pub fn run(
                 },
             ));
         });
+    true
 }

--- a/app/src/merge_test.rs
+++ b/app/src/merge_test.rs
@@ -14,6 +14,7 @@ fn merge_two_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo merge a b --into ab")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("ab", 2, Incomplete).action(Select))
         .end();
@@ -24,6 +25,7 @@ fn merge_three_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo merge a b c --into abc")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("abc", 1, Incomplete).action(Select))
         .end();
@@ -34,6 +36,7 @@ fn merge_preserves_deps() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo merge b c --into bc")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("bc", 2, Blocked).action(Select))
@@ -45,6 +48,7 @@ fn merge_preserves_adeps() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo merge a b --into ab")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("ab", 1, Incomplete).action(Select))
         .printed_task(&PrintableTask::new("c", 2, Blocked))
@@ -56,6 +60,7 @@ fn merge_preserves_deps_and_adeps() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e --chain");
     fix.test("todo merge b c d --into bcd")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("bcd", 2, Blocked).action(Select))
@@ -72,6 +77,7 @@ fn merged_task_has_min_due_date_of_sources() {
     fix.test("todo new b --due 10 min");
     fix.test("todo new c --due 20 min");
     fix.test("todo merge a b c --into abc")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("abc", 1, Incomplete)
@@ -89,6 +95,7 @@ fn merged_task_has_max_priority_of_sources() {
     fix.test("todo new c --priority 2");
     fix.test("todo new d");
     fix.test("todo merge a b c d --into abcd")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("abcd", 1, Incomplete)
@@ -103,6 +110,7 @@ fn merge_causes_cycle() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo merge a c --into ac")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotMerge {
             cycle_through: vec![BriefPrintableTask::new(2, Blocked)],
@@ -117,6 +125,7 @@ fn merge_causes_cycle_indirect() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e --chain");
     fix.test("todo merge a e --into ae")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotMerge {
             cycle_through: vec![
@@ -135,6 +144,7 @@ fn merge_inside_chain() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e f --chain");
     fix.test("todo merge c d --into cd")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 2, Blocked))
         .printed_task(&PrintableTask::new("cd", 3, Blocked).action(Select))
@@ -149,6 +159,7 @@ fn merge_task_with_snoozed_task() {
     fix.test("todo new a b");
     fix.test("todo snooze b --until 1 day");
     fix.test("todo merge a b --into ab")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("ab", 1, Blocked)
@@ -167,6 +178,7 @@ fn merge_snoozed_tasks() {
     fix.test("todo snooze b --until 2 hours");
     fix.test("todo snooze c --until 3 hours");
     fix.test("todo merge a b c --into abc")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("abc", 1, Blocked)
@@ -181,6 +193,7 @@ fn merge_tags_default() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --tag");
     fix.test("todo merge a b c --into abc")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("abc", 1, Incomplete)
@@ -195,6 +208,7 @@ fn merge_tags_into_tag() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --tag");
     fix.test("todo merge a b c --into abc --tag true")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("abc", 1, Incomplete)
@@ -209,6 +223,7 @@ fn merge_tasks_into_tag() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo merge a b c --into abc --tag true")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("abc", 1, Incomplete)
@@ -223,6 +238,7 @@ fn merge_tags_into_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --tag");
     fix.test("todo merge a b c --into abc --tag false")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("abc", 1, Incomplete).action(Select))
         .end();
@@ -234,6 +250,7 @@ fn show_tags_for_merged_task() {
     fix.test("todo new a b c --tag");
     fix.test("todo block c --on a b");
     fix.test("todo merge a b --into ab")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("ab", 1, Incomplete)

--- a/app/src/new.rs
+++ b/app/src/new.rs
@@ -1,8 +1,8 @@
 use {
     super::util::{
-        format_task, format_task_brief, format_tasks_brief,
-        lookup_tasks, parse_budget_or_print_error,
-        parse_due_date_or_print_error, parse_snooze_date_or_print_error,
+        format_task, format_task_brief, format_tasks_brief, lookup_tasks,
+        parse_budget_or_print_error, parse_due_date_or_print_error,
+        parse_snooze_date_or_print_error,
     },
     chrono::{DateTime, Utc},
     cli::New,
@@ -16,20 +16,20 @@ pub fn run(
     printer: &mut impl TodoPrinter,
     now: DateTime<Utc>,
     cmd: &New,
-) {
+) -> bool {
     let due_date = match parse_due_date_or_print_error(now, &cmd.due, printer) {
         Ok(due_date) => due_date,
-        Err(_) => return,
+        Err(_) => return false,
     };
     let budget = match parse_budget_or_print_error(&cmd.budget, printer) {
         Ok(budget) => budget,
-        Err(_) => return,
+        Err(_) => return false,
     };
     let snooze_date =
         match parse_snooze_date_or_print_error(now, &cmd.snooze, printer) {
             Ok(Some(snooze_date)) => snooze_date,
             Ok(None) => now,
-            Err(_) => return,
+            Err(_) => return false,
         };
     let deps = lookup_tasks(list, &cmd.blocked_by);
     let adeps = lookup_tasks(list, &cmd.blocking);
@@ -123,4 +123,5 @@ pub fn run(
                 },
             ));
         });
+    true
 }

--- a/app/src/new_test.rs
+++ b/app/src/new_test.rs
@@ -13,6 +13,7 @@ use {
 fn new_one_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(New))
         .end();
@@ -22,6 +23,7 @@ fn new_one_task() {
 fn new_multiple_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("b", 2, Incomplete).action(New))
@@ -35,6 +37,7 @@ fn new_block_on_complete_task() {
     fix.test("todo new a");
     fix.test("todo check 1");
     fix.test("todo new b -p 0")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete))
         .printed_task(&PrintableTask::new("b", 1, Incomplete).action(New))
@@ -47,6 +50,7 @@ fn new_blocking_complete_task() {
     fix.test("todo new a");
     fix.test("todo check 1");
     fix.test("todo new b -b 0")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("a", 2, Blocked))
@@ -58,6 +62,7 @@ fn new_by_name() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo new d -p c -b a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("c", 2, Incomplete))
         .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
@@ -69,6 +74,7 @@ fn new_by_name() {
 fn new_chain_three() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(New))
@@ -81,6 +87,7 @@ fn new_one_blocking_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo new b --blocking 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("a", 2, Blocked))
@@ -92,6 +99,7 @@ fn new_blocked_by_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo new b --blocked-by 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(New))
@@ -103,6 +111,7 @@ fn new_one_blocking_one_short() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo new b -b 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("a", 2, Blocked))
@@ -114,6 +123,7 @@ fn new_blocked_by_one_short() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo new b -p 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(New))
@@ -125,6 +135,7 @@ fn new_blocking_multiple() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo new d -b 1 2 3")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("d", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("a", 2, Blocked))
@@ -138,6 +149,7 @@ fn new_blocking_and_blocked_by() {
     let mut fix = Fixture::default();
     fix.test("todo new a b");
     fix.test("todo new c -p 1 -b 2")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Blocked).action(New))
@@ -150,6 +162,7 @@ fn new_in_between_blocking_pair() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");
     fix.test("todo new c -p 1 -b 2")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Blocked).action(New))
@@ -162,6 +175,7 @@ fn new_one_before_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo new d --before b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("d", 2, Blocked).action(New))
@@ -174,6 +188,7 @@ fn new_three_before_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo new d e f --before b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("d", 2, Blocked).action(New))
@@ -189,6 +204,7 @@ fn new_one_before_three() {
     fix.test("todo new a");
     fix.test("todo new b c d -p a");
     fix.test("todo new e --before b c d")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("e", 2, Blocked).action(New))
@@ -203,6 +219,7 @@ fn new_one_after_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo new d --after b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 2, Blocked))
         .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
@@ -215,6 +232,7 @@ fn new_three_after_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo new d e f --after b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 2, Blocked))
         .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
@@ -244,6 +262,7 @@ fn print_warning_on_cycle() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");
     fix.test("todo new c -p b -b a")
+        .modified(true)
         .validate()
         .printed_error(&PrintableError::CannotBlockBecauseWouldCauseCycle {
             cannot_block: BriefPrintableTask::new(1, Incomplete),
@@ -258,6 +277,7 @@ fn print_warning_on_cycle() {
 fn new_with_priority() {
     let mut fix = Fixture::default();
     fix.test("todo new a --priority 1")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -272,6 +292,7 @@ fn new_task_with_priority_inserted_before_unprioritized_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b");
     fix.test("todo new c --priority 1")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("c", 1, Incomplete)
@@ -286,6 +307,7 @@ fn new_task_with_negative_priority_inserted_after_unprioritized_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b");
     fix.test("todo new c --priority -1")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("c", 3, Incomplete)
@@ -301,6 +323,7 @@ fn new_task_with_priority_inserted_in_sorted_order() {
     fix.test("todo new a --priority 1");
     fix.test("todo new b --priority 3");
     fix.test("todo new c --priority 2")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("c", 2, Incomplete)
@@ -316,6 +339,7 @@ fn new_with_due_date() {
     fix.clock.now = ymdhms(2021, 04, 12, 15, 00, 00);
     let in_5_hours = ymdhms(2021, 04, 12, 20, 00, 00);
     fix.test("todo new a --due 5 hours")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -330,6 +354,7 @@ fn new_with_invalid_due_date() {
     let mut fix = Fixture::default();
     fix.clock.now = ymdhms(2021, 04, 12, 15, 00, 00);
     fix.test("todo new a --due blah blah")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotParseDueDate {
             cannot_parse: "blah blah".to_string(),
@@ -344,6 +369,7 @@ fn new_with_due_date_shows_affected_deps() {
     let in_2_days = ymdhms(2021, 04, 14, 23, 59, 59);
     fix.test("todo new a b c --chain");
     fix.test("todo new d -p c --due 2 days")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -371,6 +397,7 @@ fn new_with_budget_shows_affected_deps() {
     let end_of_day = ymdhms(2021, 04, 29, 23, 59, 59);
     fix.test("todo new a");
     fix.test("todo new b -p a --due today --budget 5 hours")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -388,6 +415,7 @@ fn new_with_budget_shows_affected_deps() {
 fn new_with_too_long_time_budget() {
     let mut fix = Fixture::default();
     fix.test("todo new a --budget 137 years")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::DurationIsTooLong {
             duration: 4323391200,
@@ -400,6 +428,7 @@ fn new_with_too_long_time_budget() {
 fn new_with_unintelligible_time_budget() {
     let mut fix = Fixture::default();
     fix.test("todo new a --budget blah")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotParseDuration {
             cannot_parse: "blah".to_string(),
@@ -411,6 +440,7 @@ fn new_with_unintelligible_time_budget() {
 fn new_invalid_snooze_date() {
     let mut fix = Fixture::default();
     fix.test("todo new a --snooze blah")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotParseDueDate {
             cannot_parse: "blah".to_string(),
@@ -423,6 +453,7 @@ fn new_snooze_one_task() {
     let mut fix = Fixture::default();
     fix.clock.now = ymdhms(2021, 05, 28, 16, 00, 00);
     fix.test("todo new a --snooze 1 day")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Blocked)
@@ -437,6 +468,7 @@ fn new_snooze_multiple_tasks() {
     let mut fix = Fixture::default();
     fix.clock.now = ymdhms(2021, 05, 28, 16, 00, 00);
     fix.test("todo new a b c --snooze 2 days")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Blocked)
@@ -460,6 +492,7 @@ fn new_snooze_multiple_tasks() {
 fn new_complete_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a --done")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(New))
         .end();
@@ -469,6 +502,7 @@ fn new_complete_task() {
 fn multiple_new_complete_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --done")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -2, Complete).action(New))
         .printed_task(&PrintableTask::new("b", -1, Complete).action(New))
@@ -480,6 +514,7 @@ fn multiple_new_complete_tasks() {
 fn new_complete_chain() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain --done")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -2, Complete).action(New))
         .printed_task(&PrintableTask::new("b", -1, Complete).action(New))
@@ -492,6 +527,7 @@ fn new_blocked_by_incomplete_task_but_tried_to_complete() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo new b -p a --done")
+        .modified(true)
         .validate()
         .printed_error(&PrintableError::CannotCheckBecauseBlocked {
             cannot_check: BriefPrintableTask::new(2, Blocked),
@@ -507,6 +543,7 @@ fn new_blocked_by_incomplete_task_and_blocks_other_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a c");
     fix.test("todo new b -p a -b c --done")
+        .modified(true)
         .validate()
         .printed_error(&PrintableError::CannotCheckBecauseBlocked {
             cannot_check: BriefPrintableTask::new(2, Blocked),
@@ -524,6 +561,7 @@ fn new_blocked_by_incomplete_task_and_blocks_other_task_with_chain() {
     fix.test("todo new a1 a2 a3");
     fix.test("todo new b1 b2 b3 -p a1 a2 a3");
     fix.test("todo new c1 c2 c3 -p b1 b2 b3 --done")
+        .modified(true)
         .validate()
         .printed_error(&PrintableError::CannotCheckBecauseBlocked {
             cannot_check: BriefPrintableTask::new(7, Blocked),
@@ -563,6 +601,7 @@ fn new_block_completed_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a --done");
     fix.test("todo new b -b a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("a", 2, Blocked))
@@ -574,6 +613,7 @@ fn new_transitively_block_completed_task() {
     let mut fix = Fixture::default();
     fix.test("todo new b c --chain --done");
     fix.test("todo new a -b b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("b", 2, Blocked))
@@ -585,6 +625,7 @@ fn new_transitively_block_completed_task() {
 fn new_as_tag() {
     let mut fix = Fixture::default();
     fix.test("todo new a --tag")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).action(New).as_tag(),
@@ -596,6 +637,7 @@ fn new_as_tag() {
 fn new_multiple_as_tag() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --tag")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).action(New).as_tag(),
@@ -614,6 +656,7 @@ fn new_blocking_tag() {
     let mut fix = Fixture::default();
     fix.test("todo new a --tag");
     fix.test("todo new b -b a")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete).action(New).tag("a"),
@@ -627,6 +670,7 @@ fn new_tag_blocking_tag() {
     let mut fix = Fixture::default();
     fix.test("todo new a --tag");
     fix.test("todo new b -b a --tag")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete)
@@ -642,6 +686,7 @@ fn new_tag_blocking_tag() {
 fn new_tag_chain() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain --tag")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)

--- a/app/src/path.rs
+++ b/app/src/path.rs
@@ -9,7 +9,11 @@ use {
 
 struct NoPathFound(TaskId, TaskId);
 
-pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Path) {
+pub fn run(
+    list: &TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: &Path,
+) -> bool {
     let tasks = cmd
         .keys
         .iter()
@@ -52,7 +56,7 @@ pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Path) {
                 format_task_brief(list, a),
                 format_task_brief(list, b),
             ));
-            return;
+            return false;
         }
     }
     .iter_sorted(list)
@@ -65,4 +69,5 @@ pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Path) {
             },
         ))
     });
+    false
 }

--- a/app/src/path_test.rs
+++ b/app/src/path_test.rs
@@ -12,6 +12,7 @@ fn path_between_tasks_with_no_path() {
     let mut fix = Fixture::default();
     fix.test("todo new a b");
     fix.test("todo path a b")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::NoPathFoundBetween(
             BriefPrintableTask::new(1, Incomplete),
@@ -25,6 +26,7 @@ fn path_between_tasks_with_direct_dependency() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");
     fix.test("todo path a b")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
@@ -36,6 +38,7 @@ fn path_between_tasks_with_indirect_dependency() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo path a c")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
         .printed_task(&PrintableTask::new("b", 2, Blocked))
@@ -48,6 +51,7 @@ fn warn_if_key_is_ambiguous() {
     let mut fix = Fixture::default();
     fix.test("todo new a a b b");
     fix.test("todo path a b")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::AmbiguousKey {
             key: Key::ByName("a".to_string()),
@@ -74,6 +78,7 @@ fn warn_if_key_is_ambiguous() {
 fn warn_if_key_has_no_match() {
     let mut fix = Fixture::default();
     fix.test("todo path a b")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::NoMatchFoundForKey {
             requested_key: Key::ByName("a".to_string()),
@@ -89,6 +94,7 @@ fn path_between_task_with_one_match() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo path a")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
         .end();
@@ -99,6 +105,7 @@ fn path_between_tasks_of_same_name() {
     let mut fix = Fixture::default();
     fix.test("todo new a b a --chain");
     fix.test("todo path a")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::AmbiguousKey {
             key: Key::ByName("a".to_string()),
@@ -118,6 +125,7 @@ fn path_between_three_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e --chain");
     fix.test("todo path a c e")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
         .printed_task(&PrintableTask::new("b", 2, Blocked))

--- a/app/src/priority_test.rs
+++ b/app/src/priority_test.rs
@@ -8,6 +8,7 @@ fn priority_set_for_one_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo priority a --is 1")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).priority(Explicit(1)),
@@ -20,6 +21,7 @@ fn priority_set_for_three_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo priority a b c --is 2")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).priority(Explicit(2)),
@@ -38,12 +40,14 @@ fn priority_reorders_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo priority b --is 1")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete).priority(Explicit(1)),
         )
         .end();
     fix.test("todo")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete).priority(Explicit(1)),
@@ -59,6 +63,7 @@ fn priority_shows_affected_deps() {
     fix.test("todo new a b c");
     fix.test("todo new d -p a c");
     fix.test("todo priority d --is 1")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
@@ -79,6 +84,7 @@ fn priority_does_not_show_complete_affected_deps() {
     fix.test("todo new d -p a c");
     fix.test("todo check a");
     fix.test("todo priority d --is 1")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("c", 1, Incomplete).priority(Implicit(1)),
@@ -96,6 +102,7 @@ fn priority_include_done() {
     fix.test("todo new d -p a c");
     fix.test("todo check a");
     fix.test("todo priority d --is 1 --include-done")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 0, Complete).priority(Implicit(1)),
@@ -114,6 +121,7 @@ fn priority_shows_affected_transitive_deps() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d --chain");
     fix.test("todo priority c --is 1")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
@@ -132,6 +140,7 @@ fn priority_set_negative() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo priority a --is -1")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 3, Incomplete).priority(Explicit(-1)),
@@ -145,8 +154,8 @@ fn priority_does_not_show_deps_with_higher_priorities() {
     fix.test("todo new a b c --priority 3");
     fix.test("todo new d e f --priority 1");
     fix.test("todo new g -p a b c d e f");
-    println!("Setting priority of g");
     fix.test("todo priority g --is 2")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("d", 4, Incomplete).priority(Implicit(2)),
@@ -170,6 +179,7 @@ fn get_all_tasks_with_priority() {
     fix.test("todo new d e f --priority 1");
     fix.test("todo new g h i --priority 2");
     fix.test("todo priority --is 2")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("g", 1, Incomplete).priority(Explicit(2)),
@@ -190,6 +200,7 @@ fn get_all_tasks_with_unspecified_priority() {
     fix.test("todo new d e f --priority 1");
     fix.test("todo new g h i --priority 2");
     fix.test("todo priority --is 1")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("g", 1, Incomplete).priority(Explicit(2)),
@@ -218,6 +229,7 @@ fn explain_source_of_priority() {
     fix.test("todo new a b c --chain");
     fix.test("todo priority c --is 1");
     fix.test("todo priority a")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
@@ -237,6 +249,7 @@ fn explain_source_of_priority_deep() {
     fix.test("todo new a b c d e f g h i --chain");
     fix.test("todo priority g --is 1");
     fix.test("todo priority a")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),

--- a/app/src/punt.rs
+++ b/app/src/punt.rs
@@ -5,7 +5,12 @@ use {
     printing::{Action, PrintableWarning, TodoPrinter},
 };
 
-pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Punt) {
+pub fn run(
+    list: &mut TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: &Punt,
+) -> bool {
+    let mut mutated = false;
     lookup_tasks(list, &cmd.keys)
         .iter_sorted(list)
         .filter(|&id| match list.punt(id) {
@@ -17,11 +22,15 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Punt) {
                 );
                 false
             }
-            _ => true,
+            _ => {
+                mutated = true;
+                true
+            }
         })
         .collect::<Vec<_>>()
         .into_iter()
         .for_each(|id| {
             printer.print_task(&format_task(list, id).action(Action::Punt))
         });
+    mutated
 }

--- a/app/src/punt_test.rs
+++ b/app/src/punt_test.rs
@@ -8,6 +8,7 @@ fn punt_first_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo punt 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 3, Incomplete).action(Punt))
         .end();
@@ -19,6 +20,9 @@ fn punt_blocked_task() {
     fix.test("todo new a");
     fix.test("todo new b c -p 1");
     fix.test("todo punt 2")
+        // TODO: Since the position of the task doesn't change, we don't
+        // need to mark the session as modified.
+        // .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("b", 3, Blocked).action(Punt))
         .end();
@@ -29,6 +33,7 @@ fn punt_by_name() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo punt a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 3, Incomplete).action(Punt))
         .end();

--- a/app/src/put.rs
+++ b/app/src/put.rs
@@ -20,7 +20,11 @@ fn print_block_error(
     });
 }
 
-pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Put) {
+pub fn run(
+    list: &mut TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: &Put,
+) -> bool {
     let tasks_to_put = lookup_tasks(list, &cmd.keys);
     let before = lookup_tasks(list, &cmd.preposition.before);
     let after = lookup_tasks(list, &cmd.preposition.after);
@@ -37,6 +41,7 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Put) {
         .fold(TaskSet::default(), |so_far, id| so_far | list.adeps(id));
     let tasks_to_block_on = after | before_deps;
     let tasks_to_block = before | after_adeps;
+    let mut mutated = false;
 
     let mut blocked_tasks = HashSet::new();
     tasks_to_put
@@ -51,6 +56,7 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Put) {
             .on(blocking)
         {
             Ok(affected) => {
+                mutated = true;
                 blocked_tasks.insert(blocked);
                 so_far | affected
             }
@@ -70,4 +76,5 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Put) {
                 },
             ))
         });
+    mutated
 }

--- a/app/src/put_test.rs
+++ b/app/src/put_test.rs
@@ -11,6 +11,7 @@ fn put_one_after_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a b");
     fix.test("todo put a --after b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
@@ -22,6 +23,7 @@ fn put_three_after_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d");
     fix.test("todo put a b c --after d")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("d", 1, Incomplete))
         .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
@@ -35,6 +37,7 @@ fn put_one_after_three() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d");
     fix.test("todo put a --after b c d")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Incomplete))
@@ -49,6 +52,7 @@ fn put_after_task_with_adeps() {
     fix.test("todo new a b --chain");
     fix.test("todo new c");
     fix.test("todo put c --after a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Blocked).action(Lock))
@@ -61,6 +65,7 @@ fn put_one_before_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a b");
     fix.test("todo put b --before a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
@@ -72,6 +77,7 @@ fn put_three_before_one() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d");
     fix.test("todo put b c d --before a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Incomplete))
@@ -85,6 +91,7 @@ fn put_one_before_three() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d");
     fix.test("todo put d --before a b c")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("d", 1, Incomplete))
         .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
@@ -99,6 +106,7 @@ fn put_before_task_with_deps() {
     fix.test("todo new a b --chain");
     fix.test("todo new c");
     fix.test("todo put c --before b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Blocked).action(Lock))
@@ -113,6 +121,7 @@ fn put_before_and_after() {
     fix.test("todo new d e f --chain");
     fix.test("todo new g");
     fix.test("todo put g -B b -A e")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("e", 3, Blocked))
@@ -127,6 +136,7 @@ fn put_causing_cycle() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");
     fix.test("todo put a --after b")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotBlockBecauseWouldCauseCycle {
             cannot_block: BriefPrintableTask::new(1, Incomplete),
@@ -134,6 +144,7 @@ fn put_causing_cycle() {
         })
         .end();
     fix.test("todo -a")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Blocked))
@@ -146,6 +157,7 @@ fn put_before_prints_updated_priority() {
     fix.test("todo new a b d --chain");
     fix.test("todo new c --priority 1");
     fix.test("todo put c --before d")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
@@ -168,6 +180,7 @@ fn put_after_prints_updated_priority() {
     fix.test("todo new a b d --chain");
     fix.test("todo new c --priority 1");
     fix.test("todo put c --after b")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
@@ -191,6 +204,7 @@ fn put_excludes_complete_affected_tasks() {
     fix.test("todo check a");
     fix.test("todo new c --priority 1");
     fix.test("todo put c --after b")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete).priority(Implicit(1)),
@@ -210,6 +224,7 @@ fn put_include_done() {
     fix.test("todo check a");
     fix.test("todo new c --priority 1");
     fix.test("todo put c --after b -d")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 0, Complete).priority(Implicit(1)),

--- a/app/src/restore.rs
+++ b/app/src/restore.rs
@@ -88,7 +88,11 @@ fn restore(
     })
 }
 
-pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Restore) {
+pub fn run(
+    list: &mut TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: &Restore,
+) -> bool {
     let tasks_to_restore =
         lookup_tasks(list, &cmd.keys).iter_sorted(list).collect();
     let result = if cmd.force {
@@ -124,4 +128,5 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Restore) {
             printer.print_task(&format_task(list, id).action(Action::Lock));
         }
     });
+    !result.restored.is_empty() || !result.blocked.is_empty()
 }

--- a/app/src/restore_test.rs
+++ b/app/src/restore_test.rs
@@ -11,6 +11,7 @@ fn restore_incomplete_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo restore 1")
+        .modified(false)
         .validate()
         .printed_warning(
             &PrintableWarning::CannotRestoreBecauseAlreadyIncomplete {
@@ -26,6 +27,7 @@ fn restore_complete_task() {
     fix.test("todo new a");
     fix.test("todo check 1");
     fix.test("todo restore 0")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
         .end();
@@ -38,6 +40,7 @@ fn restore_task_with_negative_number() {
     fix.test("todo check 1");
     fix.test("todo check 1");
     fix.test("todo restore -1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 2, Incomplete).action(Uncheck))
         .end();
@@ -49,6 +52,7 @@ fn restore_same_task_with_multiple_keys() {
     fix.test("todo new a b");
     fix.test("todo check 1");
     fix.test("todo restore 0 0")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 2, Incomplete).action(Uncheck))
         .end();
@@ -61,6 +65,7 @@ fn restore_task_with_incomplete_antidependency() {
     fix.test("todo block b --on a");
     fix.test("todo check 1");
     fix.test("todo restore 0")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(Lock))
@@ -75,6 +80,7 @@ fn restore_task_with_complete_antidependency() {
     fix.test("todo check 1");
     fix.test("todo check 1");
     fix.test("todo restore -1")
+        .modified(false)
         .validate()
         .printed_error(
             &PrintableError::CannotRestoreBecauseAntidependencyIsComplete {
@@ -93,6 +99,7 @@ fn restore_by_name() {
     fix.test("todo new a b");
     fix.test("todo check a");
     fix.test("todo restore a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 2, Incomplete).action(Uncheck))
         .end();
@@ -104,6 +111,7 @@ fn force_restore_complete_task() {
     fix.test("todo new a");
     fix.test("todo check a");
     fix.test("todo restore a --force")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
         .end();
@@ -114,6 +122,7 @@ fn force_restore_incomplete_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo restore a --force")
+        .modified(false)
         .validate()
         .printed_warning(
             &PrintableWarning::CannotRestoreBecauseAlreadyIncomplete {
@@ -129,6 +138,7 @@ fn force_restore_task_with_complete_adeps() {
     fix.test("todo new a b --chain");
     fix.test("todo check a b");
     fix.test("todo restore a --force")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(Uncheck))
@@ -141,6 +151,7 @@ fn force_restore_task_with_complete_adeps_with_complete_adeps() {
     fix.test("todo new a b c --chain");
     fix.test("todo check a b c");
     fix.test("todo restore a --force")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(Uncheck))
@@ -154,6 +165,7 @@ fn force_restore_task_with_complete_and_incomplete_adeps() {
     fix.test("todo new a b c d --chain");
     fix.test("todo check a b c");
     fix.test("todo restore a --force")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(Uncheck))
@@ -168,6 +180,7 @@ fn restore_chain() {
     fix.test("todo new a b --chain");
     fix.test("todo check a b");
     fix.test("todo restore a b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
         .printed_task(&PrintableTask::new("b", 2, Blocked).action(Uncheck))

--- a/app/src/rm.rs
+++ b/app/src/rm.rs
@@ -5,7 +5,12 @@ use {
     printing::{Action, PrintableTask, Status, TodoPrinter},
 };
 
-pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: Rm) {
+pub fn run(
+    list: &mut TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: Rm,
+) -> bool {
+    let mut mutated = false;
     lookup_tasks(list, &cmd.keys)
         .iter_sorted(list)
         .map(|id| {
@@ -15,11 +20,13 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: Rm) {
                 &PrintableTask::new(&task.desc, pos, Status::Removed)
                     .action(Action::Delete),
             );
+            mutated = true;
             id
         })
         .collect::<Vec<_>>()
         .into_iter()
         .fold(TaskSet::default(), |so_far, id| so_far | list.remove(id))
         .iter_sorted(list)
-        .for_each(|id| printer.print_task(&format_task(list, id)))
+        .for_each(|id| printer.print_task(&format_task(list, id)));
+    mutated
 }

--- a/app/src/rm_test.rs
+++ b/app/src/rm_test.rs
@@ -6,7 +6,7 @@ use {
 #[test]
 fn rm_nonexistent_task() {
     let mut fix = Fixture::default();
-    fix.test("todo rm a").validate().end();
+    fix.test("todo rm a").modified(false).validate().end();
 }
 
 #[test]
@@ -14,6 +14,7 @@ fn rm_only_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo rm a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Removed).action(Delete))
         .end();
@@ -24,6 +25,7 @@ fn rm_task_with_adeps() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");
     fix.test("todo rm a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Removed).action(Delete))
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
@@ -35,6 +37,7 @@ fn rm_task_with_deps_and_adeps() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo rm b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 2, Removed).action(Delete))
         .printed_task(&PrintableTask::new("c", 2, Blocked))
@@ -46,12 +49,14 @@ fn rm_three_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c d e");
     fix.test("todo rm a c e")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Removed).action(Delete))
         .printed_task(&PrintableTask::new("c", 3, Removed).action(Delete))
         .printed_task(&PrintableTask::new("e", 5, Removed).action(Delete))
         .end();
     fix.test("todo")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("d", 2, Incomplete))
@@ -64,6 +69,7 @@ fn rm_complete_task() {
     fix.test("todo new a");
     fix.test("todo check a");
     fix.test("todo rm a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Removed).action(Delete))
         .end();

--- a/app/src/snooze_test.rs
+++ b/app/src/snooze_test.rs
@@ -14,6 +14,7 @@ fn snooze_no_date() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo snooze a")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::EmptyDate {
             flag: Some("--until".to_string()),
@@ -27,6 +28,7 @@ fn snooze_one_task() {
     fix.clock.now = ymdhms(2021, 05, 27, 11, 00, 00);
     fix.test("todo new a b");
     fix.test("todo snooze a --until 1 day")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 2, Blocked)
@@ -42,6 +44,7 @@ fn snooze_multiple_tasks() {
     fix.clock.now = ymdhms(2021, 05, 27, 11, 00, 00);
     fix.test("todo new a b c d e");
     fix.test("todo snooze a c e --until saturday")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 3, Blocked)
@@ -67,6 +70,7 @@ fn snooze_snoozed_task() {
     fix.clock.now = ymdhms(2021, 05, 27, 11, 00, 00);
     fix.test("todo new a --snooze 2 hours");
     fix.test("todo snooze a --until 3 hours")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Blocked)
@@ -83,6 +87,7 @@ fn cannot_snooze_completed_task() {
     fix.test("todo new a");
     fix.test("todo check a");
     fix.test("todo snooze a --until saturday")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::CannotSnoozeBecauseComplete {
             cannot_snooze: BriefPrintableTask::new(0, Complete),
@@ -96,6 +101,7 @@ fn snooze_blocked_task_above_layer_1() {
     fix.clock.now = ymdhms(2021, 05, 27, 11, 00, 00);
     fix.test("todo new a b c --chain");
     fix.test("todo snooze c --until 1 day")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("c", 3, Blocked)

--- a/app/src/snoozed.rs
+++ b/app/src/snoozed.rs
@@ -9,7 +9,7 @@ pub fn run(
     list: &TodoList,
     printer: &mut impl TodoPrinter,
     now: DateTime<Utc>,
-) {
+) -> bool {
     list.all_tasks()
         .filter(|&id| {
             list.get(id)
@@ -17,4 +17,5 @@ pub fn run(
                 .unwrap_or_else(|| false)
         })
         .for_each(|id| printer.print_task(&format_task(list, id)));
+    false
 }

--- a/app/src/snoozed_test.rs
+++ b/app/src/snoozed_test.rs
@@ -6,7 +6,7 @@ use {
 #[test]
 fn no_tasks_snoozed() {
     let mut fix = Fixture::default();
-    fix.test("todo snoozed").validate().end();
+    fix.test("todo snoozed").modified(false).validate().end();
 }
 
 #[test]
@@ -15,6 +15,7 @@ fn one_snoozed_task() {
     fix.test("todo new a b c");
     fix.test("todo snooze b --until 1 hour");
     fix.test("todo snoozed")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("b", 3, Blocked))
         .end();
@@ -26,6 +27,7 @@ fn multiple_snoozed_tasks() {
     fix.test("todo new a b c d e");
     fix.test("todo snooze a b c --until 1 hour");
     fix.test("todo snoozed")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 3, Blocked))
         .printed_task(&PrintableTask::new("b", 4, Blocked))

--- a/app/src/split.rs
+++ b/app/src/split.rs
@@ -98,23 +98,25 @@ fn split(
     }
 }
 
-pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: Split) {
+pub fn run(
+    list: &mut TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: Split,
+) -> bool {
     let result = lookup_tasks(list, &cmd.keys).iter_sorted(list).fold(
         SplitResult::default(),
         |so_far, id| {
             so_far.combine(split(
                 list,
                 id,
-                cmd.into
-                    .iter()
-                    .map(|desc| desc.clone())
-                    .collect(),
+                cmd.into.to_vec(),
                 cmd.chain,
                 cmd.keep,
                 cmd.tag,
             ))
         },
     );
+    let mutated = !result.to_print.is_empty();
     result.to_print.iter_sorted(list).for_each(|id| {
         printer.print_task(&format_task(list, id).action(
             if result.shards.contains(id) {
@@ -126,4 +128,5 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: Split) {
             },
         ));
     });
+    mutated
 }

--- a/app/src/split_test.rs
+++ b/app/src/split_test.rs
@@ -13,6 +13,7 @@ fn split_one_into_three() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo split a --into a1 a2 a3")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a1", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("a2", 2, Incomplete).action(New))
@@ -25,6 +26,7 @@ fn split_chained() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo split a --into a1 a2 a3 --chain")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a1", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("a2", 2, Blocked).action(New))
@@ -37,6 +39,7 @@ fn split_preserves_dependency_structure() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo split b --into b1 b2 b3")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b1", 2, Blocked).action(New))
@@ -52,6 +55,7 @@ fn split_snoozed_task() {
     fix.clock.now = ymdhms(2021, 05, 30, 09, 00, 00);
     fix.test("todo new a --snooze 1 day");
     fix.test("todo split a --into x y")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("x", 1, Blocked)
@@ -71,6 +75,7 @@ fn chained_split_task_with_budget_distributes_budget() {
     let mut fix = Fixture::default();
     fix.test("todo new a --budget 3 hours");
     fix.test("todo split a --into x y z --chain")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("x", 1, Incomplete)
@@ -95,6 +100,7 @@ fn split_task_with_budget_keeps_budget() {
     let mut fix = Fixture::default();
     fix.test("todo new a --budget 3 hours");
     fix.test("todo split a --into x y z")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("x", 1, Incomplete)
@@ -119,6 +125,7 @@ fn split_task_keep() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo split a --into x y z --keep")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("x", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("y", 2, Incomplete).action(New))
@@ -132,6 +139,7 @@ fn split_task_keep_chained() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo split a --into x y z --keep --chain")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("x", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("y", 2, Blocked).action(New))
@@ -145,6 +153,7 @@ fn split_task_keep_with_budget() {
     let mut fix = Fixture::default();
     fix.test("todo new a --budget 3 hours");
     fix.test("todo split a --into x y z --keep")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("x", 1, Incomplete)
@@ -170,6 +179,7 @@ fn split_task_chain_keep_with_budget() {
     let mut fix = Fixture::default();
     fix.test("todo new a --budget 3 hours");
     fix.test("todo split a --into x y z --keep --chain")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("x", 1, Incomplete)
@@ -195,6 +205,7 @@ fn split_tag_default() {
     let mut fix = Fixture::default();
     fix.test("todo new a --tag");
     fix.test("todo split a --into x y z")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("x", 1, Incomplete).action(New).as_tag(),
@@ -213,6 +224,7 @@ fn split_tag_into_non_tags() {
     let mut fix = Fixture::default();
     fix.test("todo new a --tag");
     fix.test("todo split a --into x y z --tag false")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("x", 1, Incomplete).action(New))
         .printed_task(&PrintableTask::new("y", 2, Incomplete).action(New))
@@ -225,6 +237,7 @@ fn split_tag_keep() {
     let mut fix = Fixture::default();
     fix.test("todo new a --tag");
     fix.test("todo split a --into x y z --keep")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("x", 1, Incomplete).action(New).tag("a"),

--- a/app/src/status.rs
+++ b/app/src/status.rs
@@ -15,7 +15,7 @@ pub fn run(
     printer: &mut impl TodoPrinter,
     now: DateTime<Utc>,
     cmd: &Status,
-) {
+) -> bool {
     let unsnoozed_tasks = list.unsnooze_up_to(now);
     list.all_tasks()
         .filter(|&id| match list.status(id) {
@@ -32,5 +32,6 @@ pub fn run(
                     Action::None
                 },
             ))
-        })
+        });
+    !unsnoozed_tasks.is_empty()
 }

--- a/app/src/status_test.rs
+++ b/app/src/status_test.rs
@@ -9,7 +9,7 @@ use {
 #[test]
 fn status_while_empty() {
     let mut fix = Fixture::default();
-    fix.test("todo").validate().end();
+    fix.test("todo").modified(false).validate().end();
 }
 
 #[test]
@@ -17,6 +17,7 @@ fn status_after_added_tasks() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Incomplete))
@@ -30,6 +31,7 @@ fn status_does_not_include_blocked_tasks() {
     fix.test("todo new a b c");
     fix.test("todo block 2 --on 1");
     fix.test("todo")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Incomplete))
@@ -42,6 +44,7 @@ fn include_blocked_in_status() {
     fix.test("todo new a b");
     fix.test("todo block 1 --on 2");
     fix.test("todo -b")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("a", 2, Blocked))
@@ -54,6 +57,7 @@ fn include_complete_in_status() {
     fix.test("todo new a b");
     fix.test("todo check 1");
     fix.test("todo -d")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete))
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
@@ -66,6 +70,7 @@ fn include_all_in_status() {
     fix.test("todo new a b c --chain");
     fix.test("todo check 1");
     fix.test("todo -a")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete))
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
@@ -79,6 +84,7 @@ fn status_after_check_multiple_tasks() {
     fix.test("todo new a b c");
     fix.test("todo check 2 3");
     fix.test("todo")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .end();
@@ -91,6 +97,7 @@ fn status_after_unblocking_task() {
     fix.test("todo block 2 --on 1");
     fix.test("todo unblock 2 --from 1");
     fix.test("todo")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Incomplete))
@@ -105,6 +112,7 @@ fn status_unsnoozes_if_snooze_time_passed() {
     fix.test("todo snooze a --until 1 day");
     fix.clock.now = ymdhms(2021, 05, 29, 18, 00, 00);
     fix.test("todo")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Unsnooze))
         .end();
@@ -116,7 +124,7 @@ fn status_does_not_unsnooze_if_snooze_time_does_not_pass() {
     fix.clock.now = ymdhms(2021, 05, 28, 18, 00, 00);
     fix.test("todo new a");
     fix.test("todo snooze a --until 1 day");
-    fix.test("todo").validate().end();
+    fix.test("todo").modified(false).validate().end();
 }
 
 #[test]
@@ -129,6 +137,7 @@ fn status_unsnooze_preserves_order() {
     fix.test("todo snooze c --until 3 hours");
     fix.clock.now = ymdhms(2021, 05, 30, 16, 00, 00);
     fix.test("todo")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Unsnooze))
         .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Unsnooze))

--- a/app/src/tag.rs
+++ b/app/src/tag.rs
@@ -37,13 +37,18 @@ fn mark_tasks(
         })
 }
 
-pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Tag) {
+pub fn run(
+    list: &mut TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: &Tag,
+) -> bool {
     if cmd.keys.is_empty() && cmd.unmark.is_empty() {
         print_all_tags(list, printer, cmd.include_done);
-        return;
+        return false;
     }
     let tasks_to_mark = lookup_tasks(list, &cmd.keys);
     let tasks_to_unmark = lookup_tasks(list, &cmd.unmark);
+    let mut mutated = false;
     (mark_tasks(list, &tasks_to_mark, true)
         | mark_tasks(list, &tasks_to_unmark, false))
     .include_done(list, cmd.include_done)
@@ -52,10 +57,12 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Tag) {
         let task = format_task(list, id);
         printer.print_task(&task.action(
             if tasks_to_mark.contains(id) || tasks_to_unmark.contains(id) {
+                mutated = true;
                 Action::Select
             } else {
                 Action::None
             },
         ));
     });
+    mutated
 }

--- a/app/src/tag_test.rs
+++ b/app/src/tag_test.rs
@@ -6,7 +6,7 @@ use {
 #[test]
 fn tag_show_no_tags() {
     let mut fix = Fixture::default();
-    fix.test("todo tag").validate().end();
+    fix.test("todo tag").modified(false).validate().end();
 }
 
 #[test]
@@ -15,6 +15,7 @@ fn tag_show_all_tags() {
     fix.test("todo new a b c --tag");
     fix.test("todo new d e f");
     fix.test("todo tag")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).as_tag())
         .printed_task(&PrintableTask::new("b", 2, Incomplete).as_tag())
@@ -27,6 +28,7 @@ fn tag_show_blocked_tags() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --tag --chain");
     fix.test("todo tag")
+        .modified(false)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -45,6 +47,7 @@ fn tag_does_not_show_complete_tags_by_default() {
     fix.test("todo new a b c --tag");
     fix.test("todo check a");
     fix.test("todo tag")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete).as_tag())
         .printed_task(&PrintableTask::new("c", 2, Incomplete).as_tag())
@@ -57,6 +60,7 @@ fn tag_show_complete_tags() {
     fix.test("todo new a b c --tag");
     fix.test("todo check a");
     fix.test("todo tag --include-done")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).as_tag())
         .printed_task(&PrintableTask::new("b", 1, Incomplete).as_tag())
@@ -69,6 +73,7 @@ fn tag_mark_single() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo tag a")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -83,6 +88,7 @@ fn tag_mark_multiple() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo tag a b")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -102,6 +108,7 @@ fn tag_mark_already_tag() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo tag a")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -117,6 +124,7 @@ fn tag_prints_affected_deps_when_marking() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --chain");
     fix.test("todo tag c")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).tag("c"))
         .printed_task(&PrintableTask::new("b", 2, Blocked).tag("c"))
@@ -141,6 +149,7 @@ fn tag_unmark_multiple() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c --tag");
     fix.test("todo tag -u a b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
         .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Select))
@@ -151,7 +160,7 @@ fn tag_unmark_multiple() {
 fn tag_unmark_already_unmarked() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
-    fix.test("todo tag -u a").validate().end();
+    fix.test("todo tag -u a").modified(false).validate().end();
 }
 
 #[test]
@@ -160,6 +169,7 @@ fn tag_mark_and_unmark() {
     fix.test("todo new a");
     fix.test("todo new b --tag");
     fix.test("todo tag a -u b")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
@@ -176,6 +186,7 @@ fn tag_does_not_show_complete_deps_by_default_when_marking() {
     fix.test("todo new a b c --chain");
     fix.test("todo check a");
     fix.test("todo tag c")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete).tag("c"))
         .printed_task(
@@ -190,6 +201,7 @@ fn tag_show_complete_deps_when_marking() {
     fix.test("todo new a b c --chain");
     fix.test("todo check a");
     fix.test("todo tag c --include-done")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).tag("c"))
         .printed_task(&PrintableTask::new("b", 1, Incomplete).tag("c"))
@@ -206,6 +218,7 @@ fn tag_does_not_show_complete_deps_by_default_when_unmarking() {
     fix.test("todo tag c");
     fix.test("todo check a");
     fix.test("todo tag -u c")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Blocked).action(Select))
@@ -219,6 +232,7 @@ fn tag_show_complete_deps_when_unmarking() {
     fix.test("todo tag c");
     fix.test("todo check a");
     fix.test("todo tag -u c -d")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete))
         .printed_task(&PrintableTask::new("b", 1, Incomplete))

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -18,13 +18,15 @@ fn status_options(options: Options) -> status::Status {
     }
 }
 
+/// Runs the 'todo' command line application. Returns whether the list was
+/// modified; if so, the caller should save the list.
 pub fn todo(
     list: &mut TodoList,
     printer: &mut impl TodoPrinter,
     text_editor: &impl TextEditor,
     clock: &impl Clock,
     options: Options,
-) {
+) -> bool {
     use self::SubCommand::*;
     let now = clock.now();
     match options.cmd {
@@ -39,8 +41,8 @@ pub fn todo(
         Some(Get(cmd)) => get::run(list, printer, &cmd),
         Some(Log) => log::run(list, printer),
         Some(Merge(cmd)) => merge::run(list, printer, now, &cmd),
-        Some(Path(cmd)) => path::run(list, printer, &cmd),
         Some(New(cmd)) => new::run(list, printer, now, &cmd),
+        Some(Path(cmd)) => path::run(list, printer, &cmd),
         Some(Priority(cmd)) => priority::run(list, printer, &cmd),
         Some(Punt(cmd)) => punt::run(list, printer, &cmd),
         Some(Put(cmd)) => put::run(list, printer, &cmd),

--- a/app/src/top.rs
+++ b/app/src/top.rs
@@ -5,7 +5,7 @@ use {
     printing::{PrintableWarning, TodoPrinter},
 };
 
-pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Top) {
+pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Top) -> bool {
     // Handle the case where no tasks are specified. In this case, we want to
     // print all tasks that do not have any antidependencies (including complete
     // tasks iff '--include_done' is passed).)
@@ -19,7 +19,7 @@ pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Top) {
             .for_each(|id| {
                 printer.print_task(&format_task(list, id));
             });
-        return;
+        return false;
     }
 
     // Handle the case where tasks are specified. If no matches are found, print
@@ -59,4 +59,5 @@ pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Top) {
         .for_each(|id| {
             printer.print_task(&format_task(list, id));
         });
+    false
 }

--- a/app/src/top_test.rs
+++ b/app/src/top_test.rs
@@ -7,7 +7,7 @@ use {
 #[test]
 fn top_empty() {
     let mut fix = Fixture::default();
-    fix.test("todo top").validate().end();
+    fix.test("todo top").modified(false).validate().end();
 }
 
 #[test]
@@ -15,6 +15,7 @@ fn top_all_tasks_uncategorized() {
     let mut fix = Fixture::default();
     fix.test("todo new a b c");
     fix.test("todo top")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Incomplete))
@@ -28,6 +29,7 @@ fn top_all_tasks_categorized_the_same() {
     fix.test("todo new a b c");
     fix.test("todo new d -p a b c");
     fix.test("todo top")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("d", 4, Blocked))
         .end();
@@ -40,6 +42,7 @@ fn top_multiple_categories() {
     fix.test("todo new g -p a b c");
     fix.test("todo new h -p d e f");
     fix.test("todo top")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("g", 7, Blocked))
         .printed_task(&PrintableTask::new("h", 8, Blocked))
@@ -52,6 +55,7 @@ fn top_deep_category() {
     fix.test("todo new a b c --chain");
     fix.test("todo new d e f --chain");
     fix.test("todo top")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("c", 5, Blocked))
         .printed_task(&PrintableTask::new("f", 6, Blocked))
@@ -64,6 +68,7 @@ fn top_does_not_show_complete_tasks_by_default() {
     fix.test("todo new a b c");
     fix.test("todo check a");
     fix.test("todo top")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Incomplete))
@@ -76,6 +81,7 @@ fn top_show_complete_tasks_with_option() {
     fix.test("todo new a b c");
     fix.test("todo check a");
     fix.test("todo top -d")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete))
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
@@ -90,6 +96,7 @@ fn top_show_only_top_level_complete_tasks() {
     fix.test("todo new d e f --chain");
     fix.test("todo check a b c d e f");
     fix.test("todo top -d")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("c", -1, Complete))
         .printed_task(&PrintableTask::new("f", 0, Complete))
@@ -102,6 +109,7 @@ fn top_underneath_one_task() {
     fix.test("todo new a b");
     fix.test("todo new c -p a b");
     fix.test("todo top c")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Incomplete))
@@ -116,6 +124,7 @@ fn top_union_of_categories() {
     fix.test("todo new c d -b x y");
     fix.test("todo new e f -b y");
     fix.test("todo top x y")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Incomplete))
@@ -132,6 +141,7 @@ fn top_exclude_deps_with_indirect_connection_to_category() {
     fix.test("todo new x");
     fix.test("todo new a b --chain -b x");
     fix.test("todo top x")
+        .modified(false)
         .validate()
         // a should be excluded because there's also an indirect connection to
         // the top, through b. On the other hand, b is included because the only
@@ -145,6 +155,7 @@ fn top_with_typo() {
     let mut fix = Fixture::default();
     fix.test("todo new blah");
     fix.test("todo top bleh")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::NoMatchFoundForKey {
             requested_key: Key::ByName("bleh".to_string()),
@@ -158,6 +169,7 @@ fn top_implicit_include_done() {
     fix.test("todo new a b --chain");
     fix.test("todo check a b");
     fix.test("todo top b")
+        .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", -1, Complete))
         .end();

--- a/app/src/unblock.rs
+++ b/app/src/unblock.rs
@@ -56,7 +56,11 @@ fn unblock_from_all(
         })
 }
 
-pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Unblock) {
+pub fn run(
+    list: &mut TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: &Unblock,
+) -> bool {
     let tasks_to_unblock = lookup_tasks(list, &cmd.keys);
     let tasks_to_unblock_from = lookup_tasks(list, &cmd.from);
     let include_done = should_include_done(
@@ -69,8 +73,9 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Unblock) {
         printer.print_error(&PrintableError::NoMatchForKeys {
             keys: cmd.from.clone(),
         });
-        return;
+        return false;
     }
+    let mut mutated = false;
     let tasks_to_print = if tasks_to_unblock_from.is_empty() {
         unblock_from_all(list, &tasks_to_unblock)
     } else {
@@ -87,10 +92,12 @@ pub fn run(list: &mut TodoList, printer: &mut impl TodoPrinter, cmd: &Unblock) {
         .for_each(|id| {
             printer.print_task(&format_task(list, id).action(
                 if tasks_to_unblock.contains(id) {
+                    mutated = true;
                     Action::Unlock
                 } else {
                     Action::None
                 },
             ));
         });
+    mutated
 }

--- a/app/src/unblock_test.rs
+++ b/app/src/unblock_test.rs
@@ -13,6 +13,7 @@ fn unblock_task_from_direct_dependency() {
     fix.test("todo new a b");
     fix.test("todo block 2 --on 1");
     fix.test("todo unblock 2 --from 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Unlock))
@@ -26,6 +27,7 @@ fn unblock_task_from_indirect_dependency() {
     fix.test("todo block 3 --on 2");
     fix.test("todo block 2 --on 1");
     fix.test("todo unblock 3 --from 1")
+        .modified(false)
         .validate()
         .printed_warning(
             &PrintableWarning::CannotUnblockBecauseTaskIsNotBlocked {
@@ -42,6 +44,7 @@ fn unblock_complete_task() {
     fix.test("todo new a b --chain");
     fix.test("todo check 1 2");
     fix.test("todo unblock 0 --from -1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -1, Complete))
         .printed_task(&PrintableTask::new("b", 0, Complete).action(Unlock))
@@ -53,6 +56,7 @@ fn unblock_by_name() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");
     fix.test("todo unblock b --from a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Unlock))
@@ -65,6 +69,7 @@ fn unblock_from_all() {
     fix.test("todo new a b");
     fix.test("todo new c -p a b");
     fix.test("todo unblock c")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("b", 2, Incomplete))
@@ -78,6 +83,7 @@ fn unblock_from_all2() {
     fix.test("todo new a b --chain");
     fix.test("todo new c -p a b");
     fix.test("todo unblock c")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete))
         .printed_task(&PrintableTask::new("c", 2, Incomplete).action(Unlock))
@@ -91,6 +97,7 @@ fn unblock_complete() {
     fix.test("todo new a b --chain");
     fix.test("todo check a b");
     fix.test("todo unblock b")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -1, Complete))
         .printed_task(&PrintableTask::new("b", 0, Complete).action(Unlock))
@@ -102,6 +109,7 @@ fn unblock_from_matchless_key_is_error() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");
     fix.test("todo unblock b --from c")
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::NoMatchForKeys {
             keys: vec![Key::ByName("c".to_string())],
@@ -116,6 +124,7 @@ fn unblock_updates_priority() {
     fix.test("Todo new c --priority 2");
     fix.test("todo block c --on b");
     fix.test("todo unblock c --from b")
+        .modified(true)
         .validate()
         // c is printed first, because its priority is higher.
         .printed_task(
@@ -140,6 +149,7 @@ fn unblock_does_not_show_unaffected_priority() {
     fix.test("Todo new c --priority 1");
     fix.test("todo block c --on b");
     fix.test("todo unblock c --from b")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("c", 2, Incomplete)
@@ -159,6 +169,7 @@ fn unblock_excludes_affected_complete_tasks() {
     fix.test("todo priority c --is 1");
     fix.test("todo check a");
     fix.test("todo unblock c --from b")
+        .modified(true)
         .validate()
         .printed_task(
             &PrintableTask::new("c", 1, Incomplete)
@@ -176,6 +187,7 @@ fn unblock_include_done() {
     fix.test("todo priority c --is 1");
     fix.test("todo check a");
     fix.test("todo unblock c --from b -d")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete))
         .printed_task(

--- a/app/src/unsnooze.rs
+++ b/app/src/unsnooze.rs
@@ -11,7 +11,7 @@ pub fn run(
     list: &mut TodoList,
     printer: &mut impl TodoPrinter,
     cmd: &Unsnooze,
-) {
+) -> bool {
     #[derive(Default)]
     struct UnsnoozeResult {
         tasks_to_print: TaskSet,
@@ -58,4 +58,5 @@ pub fn run(
     tasks_to_print.iter_sorted(list).for_each(|id| {
         printer.print_task(&format_task(list, id).action(Action::Unsnooze));
     });
+    !tasks_to_print.is_empty()
 }

--- a/app/src/unsnooze_test.rs
+++ b/app/src/unsnooze_test.rs
@@ -15,6 +15,7 @@ fn unsnooze_snoozed_task() {
     fix.clock.now = ymdhms(2022, 02, 22, 10, 00, 00);
     fix.test("todo new a --snooze 1 hour");
     fix.test("todo unsnooze 1")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Unsnooze))
         .end();
@@ -27,6 +28,7 @@ fn unsnoozed_task_appears_at_end_of_incomplete_list() {
     fix.test("todo new a b c");
     fix.test("todo snooze a --until 1 hour");
     fix.test("todo unsnooze a")
+        .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 3, Incomplete).action(Unsnooze))
         .end();
@@ -38,6 +40,7 @@ fn unsnooze_task_that_is_not_snoozed_is_no_op() {
     fix.clock.now = ymdhms(2022, 02, 22, 10, 00, 00);
     fix.test("todo new a b c");
     fix.test("todo unsnooze b")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::CannotUnsnoozeBecauseNotSnoozed(
             BriefPrintableTask::new(2, Incomplete),
@@ -52,6 +55,7 @@ fn show_warning_when_unsnoozing_complete_task() {
     fix.test("todo new a --snooze 1 hour");
     fix.test("todo check a");
     fix.test("todo unsnooze a")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::CannotUnsnoozeBecauseComplete(
             BriefPrintableTask::new(0, Complete),
@@ -66,6 +70,7 @@ fn show_warning_when_unsnoozing_blocked_task() {
     fix.test("todo new a b --chain");
     fix.test("todo snooze b --until 1 hour");
     fix.test("todo unsnooze b")
+        .modified(false)
         .validate()
         .printed_warning(&PrintableWarning::CannotUnsnoozeBecauseBlocked {
             cannot_unsnooze: BriefPrintableTask::new(2, Blocked),

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -71,7 +71,8 @@ fn main() -> TodoResult {
         Err(_) => model::TodoList::default(),
     };
 
-    if let Some((term_width, _)) = term_size::dimensions_stdout() {
+    let mutated = if let Some((term_width, _)) = term_size::dimensions_stdout()
+    {
         let mut printer = SimpleTodoPrinter {
             out: less::Less::new(&config.paginator_cmd)?,
             context: PrintingContext {
@@ -90,7 +91,7 @@ fn main() -> TodoResult {
             &ScrawlTextEditor(&config.text_editor_cmd),
             &SystemClock,
             options,
-        );
+        )
     } else {
         app::todo(
             &mut model,
@@ -98,11 +99,13 @@ fn main() -> TodoResult {
             &FakeTextEditor::no_user_output(),
             &SystemClock,
             options,
-        );
+        )
+    };
+    if mutated {
+        let file = File::create(&data_path)?;
+        let writer = BufWriter::new(file);
+        model::save(writer, &model)?;
     }
-    let file = File::create(&data_path)?;
-    let writer = BufWriter::new(file);
-    model::save(writer, &model)?;
     Ok(())
 }
 


### PR DESCRIPTION
This lowers the risk of conflicts when multiple sessions are operating on the same list.