### PR TITLE
Add 'bottom' commnd.

### DIFF
--- a/app/src/bottom.rs
+++ b/app/src/bottom.rs
@@ -1,0 +1,57 @@
+use cli::Bottom;
+use model::{TaskSet, TaskStatus, TodoList};
+use printing::{PrintableWarning, TodoPrinter};
+
+use crate::util::{format_task, lookup_task, should_include_done};
+
+pub fn run(
+    list: &TodoList,
+    printer: &mut impl TodoPrinter,
+    cmd: &Bottom,
+) -> bool {
+    if cmd.keys.is_empty() {
+        list.all_tasks()
+            .filter(|&id| {
+                cmd.include_done
+                    || list.status(id) != Some(TaskStatus::Complete)
+            })
+            .filter(|&id| list.deps(id).is_empty())
+            .for_each(|id| {
+                printer.print_task(&format_task(list, id));
+            });
+        return false;
+    }
+    let tasks = cmd.keys.iter().fold(TaskSet::default(), |so_far, key| {
+        let tasks = lookup_task(list, key);
+        if tasks.is_empty() {
+            printer.print_warning(&PrintableWarning::NoMatchFoundForKey {
+                requested_key: key.clone(),
+            });
+        }
+        so_far | tasks
+    });
+    let include_done =
+        should_include_done(cmd.include_done, list, tasks.iter_unsorted());
+    tasks
+        .iter_unsorted()
+        // For each matching task, find the bottom tasks that they directly block.
+        // a.k.a their direct antidependencies.
+        .fold(TaskSet::default(), |so_far, id| {
+            list.adeps(id)
+                .include_done(list, include_done)
+                .iter_unsorted()
+                .filter(|&adep| {
+                    !list
+                        .deps(adep)
+                        .iter_unsorted()
+                        .any(|dep| list.transitive_deps(dep).contains(id))
+                })
+                .collect::<TaskSet>()
+                | so_far
+        })
+        .iter_sorted(list)
+        .for_each(|id| {
+            printer.print_task(&format_task(list, id));
+        });
+    false
+}

--- a/app/src/bottom_test.rs
+++ b/app/src/bottom_test.rs
@@ -1,0 +1,199 @@
+use {
+    super::testing::Fixture,
+    lookup_key::Key,
+    printing::{PrintableTask, PrintableWarning, Status::*},
+};
+
+#[test]
+fn bottom_empty() {
+    let mut fix = Fixture::default();
+    fix.test("todo bottom").modified(false).validate().end();
+}
+
+#[test]
+fn bottom_all_tasks_uncategorized() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c");
+    fix.test("todo bottom")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("b", 2, Incomplete))
+        .printed_task(&PrintableTask::new("c", 3, Incomplete))
+        .end();
+}
+
+#[test]
+fn bottom_all_tasks_categorized_the_same() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c");
+    fix.test("todo new d -p a b c");
+    fix.test("todo bottom")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("b", 2, Incomplete))
+        .printed_task(&PrintableTask::new("c", 3, Incomplete))
+        .end();
+}
+
+#[test]
+fn bottom_multiple_categories() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c d e f");
+    fix.test("todo new g -p a b c");
+    fix.test("todo new h -p d e f");
+    fix.test("todo bottom")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("b", 2, Incomplete))
+        .printed_task(&PrintableTask::new("c", 3, Incomplete))
+        .printed_task(&PrintableTask::new("d", 4, Incomplete))
+        .printed_task(&PrintableTask::new("e", 5, Incomplete))
+        .printed_task(&PrintableTask::new("f", 6, Incomplete))
+        .end();
+}
+
+#[test]
+fn bottom_deep_category() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo new d e f --chain");
+    fix.test("todo bottom")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("d", 2, Incomplete))
+        .end();
+}
+
+#[test]
+fn bottom_does_not_show_complete_tasks_by_default() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c");
+    fix.test("todo check a");
+    fix.test("todo bottom")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&PrintableTask::new("c", 2, Incomplete))
+        .end();
+}
+
+#[test]
+fn bottom_show_complete_tasks_with_option() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c");
+    fix.test("todo check a");
+    fix.test("todo bottom -d")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 0, Complete))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&PrintableTask::new("c", 2, Incomplete))
+        .end();
+}
+
+#[test]
+fn bottom_show_only_bottom_level_complete_tasks() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo new d e f --chain");
+    fix.test("todo check a b c d e f");
+    fix.test("todo bottom -d")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("a", -5, Complete))
+        .printed_task(&PrintableTask::new("d", -4, Complete))
+        .end();
+}
+
+#[test]
+fn bottom_above_top_task() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b");
+    fix.test("todo new c -p a b");
+    fix.test("todo bottom c").modified(false).validate().end();
+}
+
+#[test]
+fn bottom_above_blocking_task() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo bottom a")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("b", 2, Blocked))
+        .end();
+}
+
+#[test]
+fn bottom_above_blocked_task() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo bottom b")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("c", 3, Blocked))
+        .end();
+}
+
+#[test]
+fn bottom_above_two_tasks() {
+    let mut fix = Fixture::default();
+    fix.test("todo new x y");
+    fix.test("todo new a b -p x");
+    fix.test("todo new c d -p x y");
+    fix.test("todo new e f -p y");
+    fix.test("todo bottom x y")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 3, Blocked))
+        .printed_task(&PrintableTask::new("b", 4, Blocked))
+        .printed_task(&PrintableTask::new("c", 5, Blocked))
+        .printed_task(&PrintableTask::new("d", 6, Blocked))
+        .printed_task(&PrintableTask::new("e", 7, Blocked))
+        .printed_task(&PrintableTask::new("f", 8, Blocked))
+        .end();
+}
+
+#[test]
+fn bottom_exclude_adeps_with_indirect_connection() {
+    let mut fix = Fixture::default();
+    fix.test("todo new x");
+    fix.test("todo new a b --chain -p x");
+    fix.test("todo bottom x")
+        .modified(false)
+        .validate()
+        // b should be excluded because there's also an indirect connection to
+        // it, through a. On the other hand, a is included because the only
+        // path to it from the "bottom" task is direct.
+        .printed_task(&PrintableTask::new("a", 2, Blocked))
+        .end();
+}
+
+#[test]
+fn bottom_with_typo() {
+    let mut fix = Fixture::default();
+    fix.test("todo new blah");
+    fix.test("todo bottom bleh")
+        .modified(false)
+        .validate()
+        .printed_warning(&PrintableWarning::NoMatchFoundForKey {
+            requested_key: Key::ByName("bleh".to_string()),
+        })
+        .end();
+}
+
+#[test]
+fn bottom_implicit_include_done() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b --chain");
+    fix.test("todo check a b");
+    fix.test("todo bottom a")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("b", 0, Complete))
+        .end();
+}

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,4 +1,5 @@
 mod block;
+mod bottom;
 mod budget;
 mod chain;
 mod check;
@@ -30,6 +31,9 @@ pub use self::todo::todo;
 
 #[cfg(test)]
 mod block_test;
+
+#[cfg(test)]
+mod bottom_test;
 
 #[cfg(test)]
 mod budget_test;

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -1,8 +1,8 @@
 use {
     super::{
-        block, budget, chain, check, due, edit, find, get, log, merge, new,
-        path, priority, punt, put, restore, rm, snooze, snoozed, split, status,
-        tag, top, unblock, unsnooze,
+        block, bottom, budget, chain, check, due, edit, find, get, log, merge,
+        new, path, priority, punt, put, restore, rm, snooze, snoozed, split,
+        status, tag, top, unblock, unsnooze,
     },
     cli::{Options, SubCommand},
     clock::Clock,
@@ -31,6 +31,7 @@ pub fn todo(
     let now = clock.now();
     match options.cmd {
         Some(Block(cmd)) => block::run(list, printer, &cmd),
+        Some(Bottom(cmd)) => bottom::run(list, printer, &cmd),
         Some(Budget(cmd)) => budget::run(list, printer, &cmd),
         Some(Chain(cmd)) => chain::run(list, printer, &cmd),
         Some(Check(cmd)) => check::run(list, printer, now, &cmd),

--- a/cli/src/subcommand.rs
+++ b/cli/src/subcommand.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 #[derive(Debug, PartialEq, Eq, Parser)]
 pub enum SubCommand {
     Block(Block),
+    Bottom(Bottom),
     Budget(Budget),
     Chain(Chain),
     Check(Check),

--- a/cli/src/subcommands/bottom.rs
+++ b/cli/src/subcommands/bottom.rs
@@ -1,0 +1,19 @@
+use {clap::Parser, lookup_key::Key};
+
+/// Shows bottom-level tasks, i.e. tasks with no dependencies.
+///
+/// This is most useful for showing the *direct* anti-dependencies of given
+/// tasks. For example, if you have a task "b" that is blocked on "a", then
+/// running `todo bottom a` will show "b" as a bottom-level task.
+#[derive(Debug, PartialEq, Eq, Parser, Default)]
+#[clap(allow_negative_numbers(true), verbatim_doc_comment)]
+pub struct Bottom {
+    /// Tasks to find the bottom level above. If none are specified, shows the
+    /// bottom-level tasks, i.e. tasks with no dependencies. These may serve as
+    /// "starting points" for high-level projects.
+    pub keys: Vec<Key>,
+
+    /// If passed, shows bottom-level complete tasks too.
+    #[clap(long, short = 'd')]
+    pub include_done: bool,
+}

--- a/cli/src/subcommands/bottom_test.rs
+++ b/cli/src/subcommands/bottom_test.rs
@@ -1,0 +1,48 @@
+use {
+    crate::{testing::expect_parses_into, Bottom, SubCommand},
+    lookup_key::Key::*,
+};
+
+#[test]
+fn bottom() {
+    expect_parses_into(
+        "todo bottom",
+        SubCommand::Bottom(Bottom {
+            include_done: false,
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn bottom_include_done_long() {
+    expect_parses_into(
+        "todo bottom --include-done",
+        SubCommand::Bottom(Bottom {
+            include_done: true,
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn bottom_include_done_short() {
+    expect_parses_into(
+        "todo bottom -d",
+        SubCommand::Bottom(Bottom {
+            include_done: true,
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn bottom_with_keys() {
+    expect_parses_into(
+        "todo bottom 1 2",
+        SubCommand::Bottom(Bottom {
+            keys: vec![ByNumber(1), ByNumber(2)],
+            ..Default::default()
+        }),
+    );
+}

--- a/cli/src/subcommands/mod.rs
+++ b/cli/src/subcommands/mod.rs
@@ -1,4 +1,5 @@
 mod block;
+mod bottom;
 mod budget;
 mod chain;
 mod check;
@@ -24,6 +25,7 @@ mod unblock;
 mod unsnooze;
 
 pub use self::block::Block;
+pub use self::bottom::Bottom;
 pub use self::budget::Budget;
 pub use self::chain::Chain;
 pub use self::check::Check;
@@ -50,6 +52,9 @@ pub use self::unsnooze::Unsnooze;
 
 #[cfg(test)]
 mod block_test;
+
+#[cfg(test)]
+mod bottom_test;
 
 #[cfg(test)]
 mod budget_test;


### PR DESCRIPTION
This is the opposite of the 'top' command: if no keys are given, it prints tasks that have no dependencies, and if keys are given, it prints the direct anti-dependencies of the given tasks.

The no-key case is useful for finding tasks that can be run in parallel, or tasks that "start" a project, or tasks should be put into a structure with other bottom tasks.

The with-key case is useful for scripting: you can match the tasks that are blocked by a given task with $(todo bottom x).