### PR TITLE
Add -p and -b flags to 'get' command.

### DIFF
--- a/app/src/get.rs
+++ b/app/src/get.rs
@@ -1,3 +1,5 @@
+use model::TaskSet;
+
 use {
     super::util::{format_task, lookup_tasks, should_include_done},
     cli::Get,
@@ -12,26 +14,44 @@ pub fn run(list: &TodoList, printer: &mut impl TodoPrinter, cmd: &Get) -> bool {
         list,
         requested_tasks.iter_unsorted(),
     );
-    if cmd.no_context {
-        requested_tasks.clone()
-    } else {
-        requested_tasks.iter_sorted(list).fold(
-            requested_tasks.clone(),
-            |so_far, id| {
-                so_far | list.transitive_deps(id) | list.transitive_adeps(id)
-            },
-        )
-    }
-    .include_done(list, include_done)
-    .iter_sorted(list)
-    .for_each(|id| {
-        printer.print_task(&format_task(list, id).action(
-            if requested_tasks.contains(id) {
-                Action::Select
-            } else {
-                Action::None
-            },
-        ))
-    });
+    let (include_deps, include_adeps) =
+        match (cmd.blocking, cmd.blocked_by, cmd.no_context) {
+            // --blocking alone should show deps and not adeps.
+            (true, false, false) => (true, false),
+            // --blocked-by alone should show adeps and not deps.
+            (false, true, false) => (false, true),
+            // --no-context alone should show neither deps nor adeps.
+            (false, false, true) => (false, false),
+            // By default, show all context.
+            (false, false, false) => (true, true),
+            // Any other combination is invalid.
+            _ => unreachable!(),
+        };
+    requested_tasks
+        .iter_sorted(list)
+        .fold(requested_tasks.clone(), |so_far, id| {
+            so_far
+                | if include_deps {
+                    list.transitive_deps(id)
+                } else {
+                    TaskSet::default()
+                }
+                | if include_adeps {
+                    list.transitive_adeps(id)
+                } else {
+                    TaskSet::default()
+                }
+        })
+        .include_done(list, include_done)
+        .iter_sorted(list)
+        .for_each(|id| {
+            printer.print_task(&format_task(list, id).action(
+                if requested_tasks.contains(id) {
+                    Action::Select
+                } else {
+                    Action::None
+                },
+            ))
+        });
     false
 }

--- a/app/src/get_test.rs
+++ b/app/src/get_test.rs
@@ -188,3 +188,55 @@ fn get_no_context_complete_and_incomplete_match() {
         .printed_task(&PrintableTask::new("a", 2, Blocked).action(Select))
         .end();
 }
+
+#[test]
+fn get_blocked_by_one_task() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo get --blocked-by b")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
+        .printed_task(&PrintableTask::new("c", 3, Blocked))
+        .end();
+}
+
+#[test]
+fn get_blocked_by_shows_transitive_adeps() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c d e --chain");
+    fix.test("todo get --blocked-by b")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
+        .printed_task(&PrintableTask::new("c", 3, Blocked))
+        .printed_task(&PrintableTask::new("d", 4, Blocked))
+        .printed_task(&PrintableTask::new("e", 5, Blocked))
+        .end();
+}
+
+#[test]
+fn get_blocking_one_task() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo get --blocking b")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
+        .end();
+}
+
+#[test]
+fn get_blocking_shows_transitive_deps() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c d e --chain");
+    fix.test("todo get --blocking d")
+        .modified(false)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("b", 2, Blocked))
+        .printed_task(&PrintableTask::new("c", 3, Blocked))
+        .printed_task(&PrintableTask::new("d", 4, Blocked).action(Select))
+        .end();
+}

--- a/cli/src/subcommands/get.rs
+++ b/cli/src/subcommands/get.rs
@@ -1,3 +1,5 @@
+use clap::ArgGroup;
+
 use {clap::Parser, lookup_key::Key};
 
 /// Shows tasks related to given tasks.
@@ -27,8 +29,15 @@ use {clap::Parser, lookup_key::Key};
 /// This is also useful for seeing what tasks may be unlocked if you
 /// complete a certain task. You can use this to get a "big picture" view
 /// of how a task fits into the larger plan.
-#[derive(Debug, PartialEq, Eq, Parser)]
-#[clap(allow_negative_numbers(true), verbatim_doc_comment)]
+#[derive(Debug, Default, PartialEq, Eq, Parser)]
+#[clap(
+    allow_negative_numbers(true),
+    verbatim_doc_comment,
+    group(
+        ArgGroup::new("context")
+            .args(&["no-context", "blocked-by", "blocking"])
+    )
+)]
 pub struct Get {
     /// Tasks to explore.
     #[clap(required = true, min_values = 1)]
@@ -42,4 +51,10 @@ pub struct Get {
     /// Do not show context (transitive deps and adeps of given tasks).
     #[clap(long, short = 'n')]
     pub no_context: bool,
+    /// Only show transitive deps of given tasks.
+    #[clap(long, short = 'p')]
+    pub blocked_by: bool,
+    /// Only show transitive adeps of given tasks.
+    #[clap(long, short = 'b')]
+    pub blocking: bool,
 }

--- a/cli/src/subcommands/get_test.rs
+++ b/cli/src/subcommands/get_test.rs
@@ -12,13 +12,22 @@ fn get_missing_keys() {
 }
 
 #[test]
+fn get_mutually_exclusive_args() {
+    expect_error("todo get --no-context --blocked-by 0");
+    expect_error("todo get --no-context --blocking 0");
+    expect_error("todo get --blocked-by --blocking 0");
+    expect_error("todo get -nb 0");
+    expect_error("todo get -np 0");
+    expect_error("todo get -bp 0");
+}
+
+#[test]
 fn get_one() {
     expect_parses_into(
         "todo get 1",
         SubCommand::Get(Get {
             keys: vec![ByNumber(1)],
-            include_done: false,
-            no_context: false,
+            ..Default::default()
         }),
     );
 }
@@ -29,8 +38,7 @@ fn get_three() {
         "todo get 1 2 3",
         SubCommand::Get(Get {
             keys: vec![ByNumber(1), ByNumber(2), ByNumber(3)],
-            include_done: false,
-            no_context: false,
+            ..Default::default()
         }),
     );
 }
@@ -41,8 +49,7 @@ fn get_by_name() {
         "todo get a",
         SubCommand::Get(Get {
             keys: vec![ByName("a".to_string())],
-            include_done: false,
-            no_context: false,
+            ..Default::default()
         }),
     );
 }
@@ -53,8 +60,7 @@ fn get_negative() {
         "todo get -1",
         SubCommand::Get(Get {
             keys: vec![ByNumber(-1)],
-            include_done: false,
-            no_context: false,
+            ..Default::default()
         }),
     );
 }
@@ -66,7 +72,7 @@ fn get_include_done_long() {
         SubCommand::Get(Get {
             keys: vec![ByNumber(1)],
             include_done: true,
-            no_context: false,
+            ..Default::default()
         }),
     );
 }
@@ -78,7 +84,7 @@ fn get_include_done_short() {
         SubCommand::Get(Get {
             keys: vec![ByNumber(1)],
             include_done: true,
-            no_context: false,
+            ..Default::default()
         }),
     );
 }
@@ -89,8 +95,8 @@ fn get_no_context() {
         "todo get 1 --no-context",
         SubCommand::Get(Get {
             keys: vec![ByNumber(1)],
-            include_done: false,
             no_context: true,
+            ..Default::default()
         }),
     );
 }
@@ -101,8 +107,56 @@ fn get_no_context_short() {
         "todo get 1 -n",
         SubCommand::Get(Get {
             keys: vec![ByNumber(1)],
-            include_done: false,
             no_context: true,
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn get_blocked_by_long() {
+    expect_parses_into(
+        "todo get --blocked-by 1",
+        SubCommand::Get(Get {
+            keys: vec![ByNumber(1)],
+            blocked_by: true,
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn get_blocked_by_short() {
+    expect_parses_into(
+        "todo get -p 1",
+        SubCommand::Get(Get {
+            keys: vec![ByNumber(1)],
+            blocked_by: true,
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn get_blocking_long() {
+    expect_parses_into(
+        "todo get --blocking 1",
+        SubCommand::Get(Get {
+            keys: vec![ByNumber(1)],
+            blocking: true,
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn get_blocking_short() {
+    expect_parses_into(
+        "todo get -b 1",
+        SubCommand::Get(Get {
+            keys: vec![ByNumber(1)],
+            blocking: true,
+            ..Default::default()
         }),
     );
 }


### PR DESCRIPTION
This can be used to specifically look up transitive deps or adeps of tasks, while the default still gives both transitive deps and adeps.