### PR TITLE
Return a detailed result type from command line apps.

### DIFF
--- a/app/src/block.rs
+++ b/app/src/block.rs
@@ -4,26 +4,20 @@ use {
     },
     cli::Block,
     model::{TaskId, TaskSet, TodoList},
-    printing::{Action, PrintableError, TodoPrinter},
+    printing::{Action, PrintableAppSuccess, PrintableError, PrintableResult},
 };
 
-fn print_block_error(
-    printer: &mut impl TodoPrinter,
-    list: &TodoList,
-    blocked: TaskId,
-    blocking: TaskId,
-) {
-    printer.print_error(&PrintableError::CannotBlockBecauseWouldCauseCycle {
-        cannot_block: format_task_brief(list, blocked),
-        requested_dependency: format_task_brief(list, blocking),
-    });
+fn to_error(list: &TodoList, a: TaskId, b: TaskId) -> Vec<PrintableError> {
+    vec![PrintableError::CannotBlockBecauseWouldCauseCycle {
+        cannot_block: format_task_brief(list, a),
+        requested_dependency: format_task_brief(list, b),
+    }]
 }
 
-pub fn run(
-    list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
+pub fn run<'list>(
+    list: &'list mut TodoList,
     cmd: &Block,
-) -> bool {
+) -> PrintableResult<'list> {
     let tasks_to_block = lookup_tasks(list, &cmd.keys);
     let tasks_to_block_on = lookup_tasks(list, &cmd.on);
     let include_done = should_include_done(
@@ -31,32 +25,29 @@ pub fn run(
         list,
         (tasks_to_block.clone() | tasks_to_block_on.clone()).iter_sorted(list),
     );
-    let mut mutated = false;
-    tasks_to_block
+    let tasks_to_print: Vec<_> = tasks_to_block
         .product(&tasks_to_block_on, list)
-        .fold(TaskSet::default(), |so_far, (blocked, blocking)| match list
-            .block(blocked)
-            .on(blocking)
-        {
-            Ok(affected) => {
-                mutated = true;
-                so_far | affected
-            }
-            Err(_) => {
-                print_block_error(printer, list, blocked, blocking);
-                so_far
-            }
-        })
+        .try_fold(
+            TaskSet::default(),
+            |so_far, (a, b)| -> Result<_, Vec<PrintableError>> {
+                Ok(list.block(a).on(b).map_err(|_| to_error(list, a, b))?
+                    | so_far)
+            },
+        )?
         .include_done(list, include_done)
         .iter_sorted(list)
-        .for_each(|id| {
-            printer.print_task(&format_task(list, id).action(
-                if tasks_to_block.contains(id) {
-                    Action::Lock
-                } else {
-                    Action::None
-                },
-            ))
-        });
-    mutated
+        .map(|id| {
+            format_task(list, id).action(if tasks_to_block.contains(id) {
+                Action::Lock
+            } else {
+                Action::None
+            })
+        })
+        .collect();
+    let mutated = !tasks_to_print.is_empty();
+    Ok(PrintableAppSuccess {
+        tasks: tasks_to_print,
+        warnings: Vec::new(),
+        mutated,
+    })
 }

--- a/app/src/block.rs
+++ b/app/src/block.rs
@@ -47,7 +47,7 @@ pub fn run<'list>(
     let mutated = !tasks_to_print.is_empty();
     Ok(PrintableAppSuccess {
         tasks: tasks_to_print,
-        warnings: Vec::new(),
         mutated,
+        ..Default::default()
     })
 }

--- a/app/src/block_test.rs
+++ b/app/src/block_test.rs
@@ -99,6 +99,20 @@ fn cannot_block_on_self() {
 }
 
 #[test]
+fn cannot_block_on_adep() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b --chain");
+    fix.test("todo block a --on b")
+        .modified(false)
+        .validate()
+        .printed_error(&PrintableError::CannotBlockBecauseWouldCauseCycle {
+            cannot_block: BriefPrintableTask::new(1, Incomplete),
+            requested_dependency: BriefPrintableTask::new(2, Blocked),
+        })
+        .end();
+}
+
+#[test]
 fn block_updates_implicit_priority_of_deps() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");

--- a/app/src/bottom.rs
+++ b/app/src/bottom.rs
@@ -1,57 +1,75 @@
 use cli::Bottom;
-use model::{TaskSet, TaskStatus, TodoList};
-use printing::{PrintableWarning, TodoPrinter};
+use model::{TaskId, TaskSet, TaskStatus, TodoList};
+use printing::{PrintableAppSuccess, PrintableResult, PrintableWarning};
 
 use crate::util::{format_task, lookup_task, should_include_done};
 
-pub fn run(
+fn bottom_underneath(
     list: &TodoList,
-    printer: &mut impl TodoPrinter,
+    id: TaskId,
+    include_done: bool,
+) -> TaskSet {
+    list.adeps(id)
+        .include_done(list, include_done)
+        .iter_unsorted()
+        .filter(|&adep| {
+            !list
+                .deps(adep)
+                .iter_unsorted()
+                .any(|dep| list.transitive_deps(dep).contains(id))
+        })
+        .collect()
+}
+
+pub fn run<'list>(
+    list: &'list TodoList,
     cmd: &Bottom,
-) -> bool {
+) -> PrintableResult<'list> {
     if cmd.keys.is_empty() {
-        list.all_tasks()
+        let tasks = list
+            .all_tasks()
             .filter(|&id| {
                 cmd.include_done
                     || list.status(id) != Some(TaskStatus::Complete)
             })
             .filter(|&id| list.deps(id).is_empty())
-            .for_each(|id| {
-                printer.print_task(&format_task(list, id));
-            });
-        return false;
+            .map(|id| format_task(list, id))
+            .collect();
+        return Ok(PrintableAppSuccess {
+            tasks,
+            ..Default::default()
+        });
     }
-    let tasks = cmd.keys.iter().fold(TaskSet::default(), |so_far, key| {
-        let tasks = lookup_task(list, key);
-        if tasks.is_empty() {
-            printer.print_warning(&PrintableWarning::NoMatchFoundForKey {
-                requested_key: key.clone(),
-            });
-        }
-        so_far | tasks
-    });
-    let include_done =
-        should_include_done(cmd.include_done, list, tasks.iter_unsorted());
-    tasks
+    let (tasks_to_query, warnings) = cmd.keys.iter().fold(
+        (TaskSet::default(), Vec::new()),
+        |(so_far, mut warnings), key| {
+            let found_tasks = lookup_task(list, key);
+            if found_tasks.is_empty() {
+                warnings.push(PrintableWarning::NoMatchFoundForKey {
+                    requested_key: key.clone(),
+                });
+            }
+            (so_far | found_tasks, warnings)
+        },
+    );
+    let include_done = should_include_done(
+        cmd.include_done,
+        list,
+        tasks_to_query.iter_unsorted(),
+    );
+    let tasks = tasks_to_query
         .iter_unsorted()
-        // For each matching task, find the bottom tasks that they directly block.
-        // a.k.a their direct antidependencies.
+        // For each matching task, find the bottom tasks that they directly
+        // block, a.k.a their direct antidependencies.
         .fold(TaskSet::default(), |so_far, id| {
-            list.adeps(id)
-                .include_done(list, include_done)
-                .iter_unsorted()
-                .filter(|&adep| {
-                    !list
-                        .deps(adep)
-                        .iter_unsorted()
-                        .any(|dep| list.transitive_deps(dep).contains(id))
-                })
-                .collect::<TaskSet>()
-                | so_far
+            so_far | bottom_underneath(list, id, include_done)
         })
         .iter_sorted(list)
-        .for_each(|id| {
-            printer.print_task(&format_task(list, id));
-        });
-    false
+        .map(|id| format_task(list, id))
+        .collect();
+    Ok(PrintableAppSuccess {
+        warnings,
+        tasks,
+        mutated: false,
+    })
 }

--- a/app/src/bottom.rs
+++ b/app/src/bottom.rs
@@ -70,6 +70,6 @@ pub fn run<'list>(
     Ok(PrintableAppSuccess {
         warnings,
         tasks,
-        mutated: false,
+        ..Default::default()
     })
 }

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -4,15 +4,14 @@ use {
     },
     cli::Chain,
     model::{BlockError, TaskSet, TodoList},
-    printing::{Action, PrintableError, TodoPrinter},
+    printing::{Action, PrintableAppSuccess, PrintableError, PrintableResult},
     std::collections::HashMap,
 };
 
-pub fn run(
-    list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
+pub fn run<'list>(
+    list: &'list mut TodoList,
     cmd: &Chain,
-) -> bool {
+) -> PrintableResult<'list> {
     let tasks = cmd
         .keys
         .iter()
@@ -23,36 +22,37 @@ pub fn run(
     let mut actions = HashMap::new();
     let mut mutated = false;
     use itertools::Itertools;
-    tasks
+    let tasks_to_print = tasks
         .iter()
         .copied()
         .tuple_windows()
-        .fold(TaskSet::default(), |so_far, (a, b)| {
+        .try_fold(TaskSet::default(), |so_far, (a, b)| {
             match list.block(b).on(a) {
                 Ok(affected) => {
                     mutated = true;
                     actions.insert(b, Action::Lock);
-                    so_far | affected
+                    Ok(so_far | affected)
                 }
                 Err(BlockError::WouldCycle(_)) => {
-                    printer.print_error(
-                        &PrintableError::CannotBlockBecauseWouldCauseCycle {
-                            cannot_block: format_task_brief(list, b),
-                            requested_dependency: format_task_brief(list, a),
-                        },
-                    );
-                    so_far
+                    Err(PrintableError::CannotBlockBecauseWouldCauseCycle {
+                        cannot_block: format_task_brief(list, b),
+                        requested_dependency: format_task_brief(list, a),
+                    })
                 }
-                Err(BlockError::WouldBlockOnSelf) => so_far,
+                Err(BlockError::WouldBlockOnSelf) => Ok(so_far),
             }
         })
+        .map_err(|e| vec![e])?
         .include_done(list, include_done)
         .iter_sorted(list)
-        .for_each(|id| {
-            printer.print_task(
-                &format_task(list, id)
-                    .action(*actions.get(&id).unwrap_or(&Action::None)),
-            );
-        });
-    mutated
+        .map(|id| {
+            format_task(list, id)
+                .action(*actions.get(&id).unwrap_or(&Action::None))
+        })
+        .collect();
+    Ok(PrintableAppSuccess {
+        tasks: tasks_to_print,
+        mutated,
+        ..Default::default()
+    })
 }

--- a/app/src/check.rs
+++ b/app/src/check.rs
@@ -157,5 +157,6 @@ pub fn run<'list>(
         warnings,
         tasks: tasks_to_print,
         mutated,
+        ..Default::default()
     })
 }

--- a/app/src/edit.rs
+++ b/app/src/edit.rs
@@ -36,8 +36,8 @@ fn edit_with_description<'list>(
     let mutated = !tasks_to_print.is_empty();
     Ok(PrintableAppSuccess {
         tasks: tasks_to_print,
-        warnings: vec![],
         mutated,
+        ..Default::default()
     })
 }
 
@@ -112,8 +112,8 @@ fn edit_with_text_editor<'list>(
         .collect();
     Ok(PrintableAppSuccess {
         tasks: tasks_to_print,
-        warnings: vec![],
         mutated,
+        ..Default::default()
     })
 }
 

--- a/app/src/edit.rs
+++ b/app/src/edit.rs
@@ -1,9 +1,11 @@
+use printing::{PrintableAppSuccess, PrintableResult};
+
 use {
     super::util::{format_task, lookup_tasks},
     cli::Edit,
     itertools::Itertools,
     model::{TaskId, TaskSet, TodoList},
-    printing::{PrintableError, TodoPrinter},
+    printing::PrintableError,
     std::borrow::Cow,
     text_editing::TextEditor,
 };
@@ -19,22 +21,24 @@ fn format_tasks_for_text_editor(list: &TodoList, ids: &TaskSet) -> String {
         .join("\n")
 }
 
-fn edit_with_description(
-    list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
+fn edit_with_description<'list>(
+    list: &'list mut TodoList,
     ids: &TaskSet,
     desc: &str,
-) -> bool {
-    let mut mutated = false;
-    ids.iter_sorted(list)
-        .filter(|&id| list.set_desc(id, Cow::Owned(desc.to_string())))
-        .collect::<TaskSet>()
+) -> PrintableResult<'list> {
+    let tasks_to_print: Vec<_> = ids
         .iter_sorted(list)
-        .for_each(|id| {
-            printer.print_task(&format_task(list, id));
-            mutated = true;
-        });
-    mutated
+        .filter(|&id| list.set_desc(id, Cow::Owned(desc.to_string())))
+        .collect::<Vec<_>>()
+        .into_iter()
+        .map(|id| format_task(list, id))
+        .collect();
+    let mutated = !tasks_to_print.is_empty();
+    Ok(PrintableAppSuccess {
+        tasks: tasks_to_print,
+        warnings: vec![],
+        mutated,
+    })
 }
 
 enum EditError {
@@ -59,89 +63,75 @@ fn parse_line_from_text_editor(line: &str) -> Result<(i32, String), EditError> {
 
 fn update_desc(
     list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
     ids: &TaskSet,
     pos: i32,
     desc: &str,
-) -> Option<TaskId> {
+) -> Result<TaskId, PrintableError> {
     match list.lookup_by_number(pos) {
         Some(id) => {
             if !ids.contains(id) {
-                printer.print_error(
-                    &PrintableError::CannotEditBecauseUnexpectedNumber {
-                        requested: pos,
-                    },
-                );
-                None
+                Err(PrintableError::CannotEditBecauseUnexpectedNumber {
+                    requested: pos,
+                })
             } else {
-                Some(id)
+                list.set_desc(id, Cow::Owned(desc.to_string()));
+                Ok(id)
             }
         }
-        _ => {
-            printer.print_error(
-                &PrintableError::CannotEditBecauseNoTaskWithNumber {
-                    requested: pos,
-                },
-            );
-            None
-        }
+        _ => Err(PrintableError::CannotEditBecauseNoTaskWithNumber {
+            requested: pos,
+        }),
     }
-    .filter(|&id| list.set_desc(id, Cow::Owned(desc.to_string())))
 }
 
-fn edit_with_text_editor(
-    list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
+fn edit_with_text_editor<'list>(
+    list: &'list mut TodoList,
     ids: &TaskSet,
     editor_output: &str,
-) -> bool {
+) -> PrintableResult<'list> {
     let mut mutated = false;
-    editor_output
+    let tasks_to_print = editor_output
         .lines()
-        .flat_map(|line| {
+        .try_fold(TaskSet::default(), |so_far, line| {
             match parse_line_from_text_editor(line) {
-                Ok((pos, desc)) => update_desc(list, printer, ids, pos, &desc),
-                Err(_) => {
-                    printer.print_error(
-                        &PrintableError::CannotEditBecauseInvalidLine {
-                            malformed_line: line.to_string(),
+                Ok((pos, desc)) => Ok(so_far
+                    | TaskSet::of(update_desc(list, ids, pos, &desc).map(
+                        |x| {
+                            mutated = true;
+                            x
                         },
-                    );
-                    None
-                }
+                    )?)),
+                Err(_) => Err(PrintableError::CannotEditBecauseInvalidLine {
+                    malformed_line: line.to_string(),
+                }),
             }
-            .into_iter()
         })
-        .collect::<TaskSet>()
+        .map_err(|e| vec![e])?
         .iter_sorted(list)
-        .for_each(|id| {
-            printer.print_task(&format_task(list, id));
-            mutated = true;
-        });
-    mutated
+        .map(|id| format_task(list, id))
+        .collect();
+    Ok(PrintableAppSuccess {
+        tasks: tasks_to_print,
+        warnings: vec![],
+        mutated,
+    })
 }
 
-pub fn run(
-    list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
+pub fn run<'list>(
+    list: &'list mut TodoList,
     text_editor: &impl TextEditor,
     cmd: &Edit,
-) -> bool {
+) -> PrintableResult<'list> {
     let tasks_to_edit = lookup_tasks(list, &cmd.keys);
     match &cmd.desc {
-        Some(ref desc) => {
-            edit_with_description(list, printer, &tasks_to_edit, desc)
-        }
+        Some(ref desc) => edit_with_description(list, &tasks_to_edit, desc),
         None => match text_editor
             .edit_text(&format_tasks_for_text_editor(list, &tasks_to_edit))
         {
             Ok(ref output) => {
-                edit_with_text_editor(list, printer, &tasks_to_edit, output)
+                edit_with_text_editor(list, &tasks_to_edit, output)
             }
-            Err(_) => {
-                printer.print_error(&PrintableError::FailedToUseTextEditor);
-                false
-            }
+            Err(_) => Err(vec![PrintableError::FailedToUseTextEditor]),
         },
     }
 }

--- a/app/src/log.rs
+++ b/app/src/log.rs
@@ -2,33 +2,36 @@ use {
     super::util::format_task,
     chrono::{Datelike, Local},
     model::TodoList,
-    printing::{LogDate, TodoPrinter},
+    printing::{LogDate, PrintableAppSuccess, PrintableResult},
 };
 
-pub fn run(list: &TodoList, printer: &mut impl TodoPrinter) -> bool {
+pub fn run<'list>(list: &'list TodoList) -> PrintableResult<'list> {
     let mut most_recent_shown = None;
-    list.complete_tasks().for_each(|id| {
-        let mut formatted_task = format_task(list, id);
-        let to_show =
-            list.get(id)
-                .unwrap()
-                .completion_time
-                .map(|completion_time| {
-                    let completion_time = completion_time.with_timezone(&Local);
-                    LogDate::YearMonthDay(
-                        completion_time.year() as u16,
-                        completion_time.month() as u8,
-                        completion_time.day() as u8,
-                    )
-                });
-        formatted_task =
-            formatted_task.log_date(if to_show != most_recent_shown {
-                most_recent_shown = to_show.clone();
-                to_show.unwrap()
-            } else {
-                LogDate::Invisible
-            });
-        printer.print_task(&formatted_task);
-    });
-    false
+    let tasks_to_print =
+        list.complete_tasks()
+            .map(|id| {
+                let formatted_task = format_task(list, id);
+                let to_show = list.get(id).unwrap().completion_time.map(
+                    |completion_time| {
+                        let completion_time =
+                            completion_time.with_timezone(&Local);
+                        LogDate::YearMonthDay(
+                            completion_time.year() as u16,
+                            completion_time.month() as u8,
+                            completion_time.day() as u8,
+                        )
+                    },
+                );
+                formatted_task.log_date(if to_show != most_recent_shown {
+                    most_recent_shown = to_show.clone();
+                    to_show.unwrap()
+                } else {
+                    LogDate::Invisible
+                })
+            })
+            .collect();
+    Ok(PrintableAppSuccess {
+        tasks: tasks_to_print,
+        ..Default::default()
+    })
 }

--- a/app/src/merge.rs
+++ b/app/src/merge.rs
@@ -107,7 +107,7 @@ pub fn run<'list>(
         .collect();
     Ok(PrintableAppSuccess {
         tasks: tasks_to_print,
-        warnings: vec![],
         mutated: true,
+        ..Default::default()
     })
 }

--- a/app/src/merge.rs
+++ b/app/src/merge.rs
@@ -3,16 +3,15 @@ use {
     chrono::{DateTime, Utc},
     cli::Merge,
     model::{DurationInSeconds, NewOptions, TaskSet, TodoList},
-    printing::{Action, PrintableError, TodoPrinter},
+    printing::{Action, PrintableAppSuccess, PrintableError, PrintableResult},
     std::borrow::Cow,
 };
 
-pub fn run(
-    list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
+pub fn run<'list>(
+    list: &'list mut TodoList,
     now: DateTime<Utc>,
     cmd: &Merge,
-) -> bool {
+) -> PrintableResult<'list> {
     let tasks_to_merge = lookup_tasks(list, &cmd.keys);
     let deps = tasks_to_merge
         .iter_unsorted()
@@ -44,12 +43,11 @@ pub fn run(
             .iter_unsorted()
             .fold(TaskSet::default(), |so_far, id| so_far | list.adeps(id))
             & tasks_to_merge;
-        printer.print_error(&PrintableError::CannotMerge {
+        return Err(vec![PrintableError::CannotMerge {
             cycle_through: format_tasks_brief(list, &cycle_through),
             adeps_of: format_tasks_brief(list, &adeps_of),
             deps_of: format_tasks_brief(list, &deps_of),
-        });
-        return false;
+        }]);
     }
     let priority = tasks_to_merge
         .iter_unsorted()
@@ -97,16 +95,19 @@ pub fn run(
     tasks_to_merge.iter_sorted(list).for_each(|id| {
         list.remove(id);
     });
-    (deps | TaskSet::of(merged) | adeps)
+    let tasks_to_print = (deps | TaskSet::of(merged) | adeps)
         .iter_sorted(list)
-        .for_each(|id| {
-            printer.print_task(&format_task(list, id).action(
-                if id == merged {
-                    Action::Select
-                } else {
-                    Action::None
-                },
-            ));
-        });
-    true
+        .map(|id| {
+            format_task(list, id).action(if id == merged {
+                Action::Select
+            } else {
+                Action::None
+            })
+        })
+        .collect();
+    Ok(PrintableAppSuccess {
+        tasks: tasks_to_print,
+        warnings: vec![],
+        mutated: true,
+    })
 }

--- a/app/src/new_test.rs
+++ b/app/src/new_test.rs
@@ -262,14 +262,12 @@ fn print_warning_on_cycle() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");
     fix.test("todo new c -p b -b a")
-        .modified(true)
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotBlockBecauseWouldCauseCycle {
             cannot_block: BriefPrintableTask::new(1, Incomplete),
             requested_dependency: BriefPrintableTask::new(3, Blocked),
         })
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("c", 3, Blocked).action(New))
         .end();
 }
 
@@ -527,14 +525,12 @@ fn new_blocked_by_incomplete_task_but_tried_to_complete() {
     let mut fix = Fixture::default();
     fix.test("todo new a");
     fix.test("todo new b -p a --done")
-        .modified(true)
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotCheckBecauseBlocked {
             cannot_check: BriefPrintableTask::new(2, Blocked),
             blocked_by: vec![BriefPrintableTask::new(1, Incomplete)],
         })
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(New))
         .end();
 }
 
@@ -543,15 +539,12 @@ fn new_blocked_by_incomplete_task_and_blocks_other_task() {
     let mut fix = Fixture::default();
     fix.test("todo new a c");
     fix.test("todo new b -p a -b c --done")
-        .modified(true)
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotCheckBecauseBlocked {
             cannot_check: BriefPrintableTask::new(2, Blocked),
             blocked_by: vec![BriefPrintableTask::new(1, Incomplete)],
         })
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c", 3, Blocked))
         .end();
 }
 
@@ -561,7 +554,7 @@ fn new_blocked_by_incomplete_task_and_blocks_other_task_with_chain() {
     fix.test("todo new a1 a2 a3");
     fix.test("todo new b1 b2 b3 -p a1 a2 a3");
     fix.test("todo new c1 c2 c3 -p b1 b2 b3 --done")
-        .modified(true)
+        .modified(false)
         .validate()
         .printed_error(&PrintableError::CannotCheckBecauseBlocked {
             cannot_check: BriefPrintableTask::new(7, Blocked),
@@ -571,28 +564,6 @@ fn new_blocked_by_incomplete_task_and_blocks_other_task_with_chain() {
                 BriefPrintableTask::new(6, Blocked),
             ],
         })
-        .printed_error(&PrintableError::CannotCheckBecauseBlocked {
-            cannot_check: BriefPrintableTask::new(8, Blocked),
-            blocked_by: vec![
-                BriefPrintableTask::new(4, Blocked),
-                BriefPrintableTask::new(5, Blocked),
-                BriefPrintableTask::new(6, Blocked),
-            ],
-        })
-        .printed_error(&PrintableError::CannotCheckBecauseBlocked {
-            cannot_check: BriefPrintableTask::new(9, Blocked),
-            blocked_by: vec![
-                BriefPrintableTask::new(4, Blocked),
-                BriefPrintableTask::new(5, Blocked),
-                BriefPrintableTask::new(6, Blocked),
-            ],
-        })
-        .printed_task(&PrintableTask::new("b1", 4, Blocked))
-        .printed_task(&PrintableTask::new("b2", 5, Blocked))
-        .printed_task(&PrintableTask::new("b3", 6, Blocked))
-        .printed_task(&PrintableTask::new("c1", 7, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c2", 8, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c3", 9, Blocked).action(New))
         .end();
 }
 

--- a/app/src/punt.rs
+++ b/app/src/punt.rs
@@ -1,36 +1,43 @@
 use {
     super::util::{format_task, format_task_brief, lookup_tasks},
     cli::Punt,
-    model::{PuntError, TodoList},
-    printing::{Action, PrintableWarning, TodoPrinter},
+    model::{PuntError, TaskSet, TodoList},
+    printing::{
+        Action, PrintableAppSuccess, PrintableResult, PrintableWarning,
+    },
 };
 
-pub fn run(
-    list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
+pub fn run<'list>(
+    list: &'list mut TodoList,
     cmd: &Punt,
-) -> bool {
-    let mut mutated = false;
-    lookup_tasks(list, &cmd.keys)
+) -> PrintableResult<'list> {
+    let (punted_tasks, warnings, mutated) =
+        lookup_tasks(list, &cmd.keys).iter_sorted(list).fold(
+            (TaskSet::default(), Vec::new(), false),
+            |(mut punted_tasks, mut warnings, mut mutated), id| {
+                match list.punt(id) {
+                    Err(PuntError::TaskIsComplete) => {
+                        warnings.push(
+                            PrintableWarning::CannotPuntBecauseComplete {
+                                cannot_punt: format_task_brief(list, id),
+                            },
+                        );
+                    }
+                    _ => {
+                        mutated = true;
+                        punted_tasks = punted_tasks | TaskSet::of(id);
+                    }
+                }
+                (punted_tasks, warnings, mutated)
+            },
+        );
+    let tasks_to_print = punted_tasks
         .iter_sorted(list)
-        .filter(|&id| match list.punt(id) {
-            Err(PuntError::TaskIsComplete) => {
-                printer.print_warning(
-                    &PrintableWarning::CannotPuntBecauseComplete {
-                        cannot_punt: format_task_brief(list, id),
-                    },
-                );
-                false
-            }
-            _ => {
-                mutated = true;
-                true
-            }
-        })
-        .collect::<Vec<_>>()
-        .into_iter()
-        .for_each(|id| {
-            printer.print_task(&format_task(list, id).action(Action::Punt))
-        });
-    mutated
+        .map(|id| format_task(list, id).action(Action::Punt))
+        .collect();
+    Ok(PrintableAppSuccess {
+        tasks: tasks_to_print,
+        warnings,
+        mutated,
+    })
 }

--- a/app/src/punt.rs
+++ b/app/src/punt.rs
@@ -39,5 +39,6 @@ pub fn run<'list>(
         tasks: tasks_to_print,
         warnings,
         mutated,
+        ..Default::default()
     })
 }

--- a/app/src/put.rs
+++ b/app/src/put.rs
@@ -4,27 +4,25 @@ use {
     },
     cli::Put,
     model::{TaskId, TaskSet, TodoList},
-    printing::{Action, PrintableError, TodoPrinter},
+    printing::{Action, PrintableAppSuccess, PrintableError, PrintableResult},
     std::collections::HashSet,
 };
 
 fn print_block_error(
-    printer: &mut impl TodoPrinter,
     list: &TodoList,
     blocked: TaskId,
     blocking: TaskId,
-) {
-    printer.print_error(&PrintableError::CannotBlockBecauseWouldCauseCycle {
+) -> PrintableError {
+    PrintableError::CannotBlockBecauseWouldCauseCycle {
         cannot_block: format_task_brief(list, blocked),
         requested_dependency: format_task_brief(list, blocking),
-    });
+    }
 }
 
-pub fn run(
-    list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
+pub fn run<'list>(
+    list: &'list mut TodoList,
     cmd: &Put,
-) -> bool {
+) -> PrintableResult<'list> {
     let tasks_to_put = lookup_tasks(list, &cmd.keys);
     let before = lookup_tasks(list, &cmd.preposition.before);
     let after = lookup_tasks(list, &cmd.preposition.after);
@@ -44,37 +42,37 @@ pub fn run(
     let mut mutated = false;
 
     let mut blocked_tasks = HashSet::new();
-    tasks_to_put
+    let tasks_to_print = tasks_to_put
         .product(&tasks_to_block_on, list)
         .chain(
             tasks_to_put
                 .product(&tasks_to_block, list)
                 .map(|(a, b)| (b, a)),
         )
-        .fold(TaskSet::default(), |so_far, (blocked, blocking)| match list
+        .try_fold(TaskSet::default(), |so_far, (blocked, blocking)| match list
             .block(blocked)
             .on(blocking)
         {
             Ok(affected) => {
                 mutated = true;
                 blocked_tasks.insert(blocked);
-                so_far | affected
+                Ok(so_far | affected)
             }
-            Err(_) => {
-                print_block_error(printer, list, blocked, blocking);
-                so_far
-            }
-        })
+            Err(_) => Err(vec![print_block_error(list, blocked, blocking)]),
+        })?
         .include_done(list, include_done)
         .iter_sorted(list)
-        .for_each(|id| {
-            printer.print_task(&format_task(list, id).action(
-                if blocked_tasks.contains(&id) {
-                    Action::Lock
-                } else {
-                    Action::None
-                },
-            ))
-        });
-    mutated
+        .map(|id| {
+            format_task(list, id).action(if blocked_tasks.contains(&id) {
+                Action::Lock
+            } else {
+                Action::None
+            })
+        })
+        .collect();
+    Ok(PrintableAppSuccess {
+        tasks: tasks_to_print,
+        mutated,
+        ..Default::default()
+    })
 }

--- a/app/src/restore.rs
+++ b/app/src/restore.rs
@@ -153,5 +153,6 @@ pub fn run<'list>(
         tasks: tasks_to_print,
         warnings,
         mutated,
+        ..Default::default()
     })
 }

--- a/app/src/rm_test.rs
+++ b/app/src/rm_test.rs
@@ -1,7 +1,13 @@
 use {
     super::testing::Fixture,
-    printing::{Action::*, PrintableTask, Status::*},
+    printing::{PrintableInfo, PrintableTask, Status::*},
 };
+
+fn info_removed(desc: &str) -> PrintableInfo {
+    PrintableInfo::Removed {
+        desc: desc.to_string(),
+    }
+}
 
 #[test]
 fn rm_nonexistent_task() {
@@ -16,7 +22,7 @@ fn rm_only_task() {
     fix.test("todo rm a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Removed).action(Delete))
+        .printed_info(&info_removed("a"))
         .end();
 }
 
@@ -27,7 +33,7 @@ fn rm_task_with_adeps() {
     fix.test("todo rm a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Removed).action(Delete))
+        .printed_info(&info_removed("a"))
         .printed_task(&PrintableTask::new("b", 1, Incomplete))
         .end();
 }
@@ -39,7 +45,7 @@ fn rm_task_with_deps_and_adeps() {
     fix.test("todo rm b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Removed).action(Delete))
+        .printed_info(&info_removed("b"))
         .printed_task(&PrintableTask::new("c", 2, Blocked))
         .end();
 }
@@ -51,9 +57,9 @@ fn rm_three_tasks() {
     fix.test("todo rm a c e")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Removed).action(Delete))
-        .printed_task(&PrintableTask::new("c", 3, Removed).action(Delete))
-        .printed_task(&PrintableTask::new("e", 5, Removed).action(Delete))
+        .printed_info(&info_removed("a"))
+        .printed_info(&info_removed("c"))
+        .printed_info(&info_removed("e"))
         .end();
     fix.test("todo")
         .modified(false)
@@ -71,6 +77,6 @@ fn rm_complete_task() {
     fix.test("todo rm a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Removed).action(Delete))
+        .printed_info(&info_removed("a"))
         .end();
 }

--- a/app/src/snooze.rs
+++ b/app/src/snooze.rs
@@ -59,6 +59,18 @@ pub fn run<'list>(
                         warnings.extend(
                             new_warnings
                                 .into_iter()
+                                .inspect(|w| {
+                                    if let
+                                    SnoozeWarning::SnoozedUntilAfterDueDate{
+                                        snoozed_until: _, due_date: _
+                                    } = w {
+                                        mutated = true;
+                                        // TODO: Make a push() method for
+                                        // TaskSet so we don't have to clone
+                                        // here.
+                                        snoozed = snoozed.clone() | TaskSet::of(id);
+                                    }
+                                })
                                 .map(|w| format_snooze_warning(list, id, w)),
                         );
                     }

--- a/app/src/snooze.rs
+++ b/app/src/snooze.rs
@@ -1,76 +1,78 @@
 use {
     super::util::{
-        format_task, format_task_brief, lookup_tasks,
-        parse_snooze_date_or_print_error,
+        format_task, format_task_brief, lookup_tasks, parse_snooze_date,
     },
     chrono::{DateTime, Utc},
     cli::Snooze,
-    model::{SnoozeWarning, TaskSet, TodoList},
-    printing::{Action, PrintableError, PrintableWarning, TodoPrinter},
+    model::{SnoozeWarning, TaskId, TaskSet, TodoList},
+    printing::{
+        Action, PrintableAppSuccess, PrintableError, PrintableResult,
+        PrintableWarning,
+    },
 };
 
-pub fn run(
-    list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
+fn format_snooze_warning(
+    list: &TodoList,
+    id: TaskId,
+    warning: SnoozeWarning,
+) -> PrintableWarning {
+    match warning {
+        SnoozeWarning::TaskIsComplete => {
+            PrintableWarning::CannotSnoozeBecauseComplete {
+                cannot_snooze: format_task_brief(list, id),
+            }
+        }
+        SnoozeWarning::SnoozedUntilAfterDueDate {
+            snoozed_until,
+            due_date,
+        } => PrintableWarning::SnoozedAfterDueDate {
+            snoozed_task: format_task_brief(list, id),
+            due_date,
+            snooze_date: snoozed_until,
+        },
+    }
+}
+
+pub fn run<'list>(
+    list: &'list mut TodoList,
     now: DateTime<Utc>,
     cmd: &Snooze,
-) -> bool {
-    let snooze_date =
-        match parse_snooze_date_or_print_error(now, &cmd.until, printer) {
-            Ok(Some(snooze_date)) => snooze_date,
-            Ok(None) => {
-                printer.print_error(&PrintableError::EmptyDate {
-                    flag: Some("--until".to_string()),
-                });
-                return false;
-            }
-            Err(()) => {
-                return false;
-            }
-        };
-    let mut mutated = false;
-    lookup_tasks(list, &cmd.keys)
-        .iter_sorted(list)
-        .filter(|&id| match list.snooze(id, snooze_date) {
-            Ok(()) => {
-                mutated = true;
-                true
-            }
-            Err(warnings) => warnings.into_iter().fold(
-                true,
-                |snoozed, warning| match warning {
-                    SnoozeWarning::TaskIsComplete => {
-                        printer.print_warning(
-                            &PrintableWarning::CannotSnoozeBecauseComplete {
-                                cannot_snooze: format_task_brief(list, id),
-                            },
-                        );
-                        false
-                    }
-                    SnoozeWarning::SnoozedUntilAfterDueDate {
-                        snoozed_until,
-                        due_date,
-                    } => {
-                        printer.print_warning(
-                            &PrintableWarning::SnoozedAfterDueDate {
-                                snoozed_task: format_task_brief(list, id),
-                                due_date,
-                                snooze_date: snoozed_until,
-                            },
-                        );
-                        snoozed
-                    }
-                },
-            ),
+) -> PrintableResult<'list> {
+    let snooze_date = parse_snooze_date(now, &cmd.until)
+        .and_then(|date| match date {
+            Some(date) => Ok(date),
+            None => Err(PrintableError::EmptyDate {
+                flag: Some("--until".to_string()),
+            }),
         })
-        .collect::<TaskSet>()
+        .map_err(|e| vec![e])?;
+    let (snoozed, warnings, mutated) =
+        lookup_tasks(list, &cmd.keys).iter_sorted(list).fold(
+            (TaskSet::default(), Vec::new(), false),
+            |(mut snoozed, mut warnings, mut mutated), id| {
+                match list.snooze(id, snooze_date) {
+                    Ok(()) => {
+                        mutated = true;
+                        snoozed = snoozed | TaskSet::of(id);
+                    }
+                    Err(new_warnings) => {
+                        warnings.extend(
+                            new_warnings
+                                .into_iter()
+                                .map(|w| format_snooze_warning(list, id, w)),
+                        );
+                    }
+                };
+                (snoozed, warnings, mutated)
+            },
+        );
+    let tasks_to_print = snoozed
         .iter_sorted(list)
-        .for_each(|id| {
-            printer.print_task(
-                &format_task(list, id)
-                    .action(Action::Snooze)
-                    .start_date(snooze_date),
-            )
-        });
-    mutated
+        .map(|id| format_task(list, id).action(Action::Snooze))
+        .collect();
+    Ok(PrintableAppSuccess {
+        tasks: tasks_to_print,
+        warnings,
+        mutated,
+    })
 }

--- a/app/src/snooze.rs
+++ b/app/src/snooze.rs
@@ -86,5 +86,6 @@ pub fn run<'list>(
         tasks: tasks_to_print,
         warnings,
         mutated,
+        ..Default::default()
     })
 }

--- a/app/src/snooze_test.rs
+++ b/app/src/snooze_test.rs
@@ -110,3 +110,24 @@ fn snooze_blocked_task_above_layer_1() {
         )
         .end();
 }
+
+#[test]
+fn snooze_after_due_date() {
+    let mut fix = Fixture::default();
+    fix.clock.now = ymdhms(2022, 10, 02, 23, 00, 00);
+    fix.test("todo new a --due 1 day");
+    fix.test("todo snooze a --until 2 days")
+        .modified(true)
+        .validate()
+        .printed_warning(&PrintableWarning::SnoozedAfterDueDate {
+            snoozed_task: BriefPrintableTask::new(1, Blocked),
+            due_date: ymdhms(2022, 10, 03, 23, 59, 59),
+            snooze_date: ymdhms(2022, 10, 04, 00, 00, 00),
+        })
+        .printed_task(
+            &PrintableTask::new("a", 1, Blocked)
+                .start_date(ymdhms(2022, 10, 04, 00, 00, 00))
+                .action(Snooze),
+        )
+        .end();
+}

--- a/app/src/snoozed.rs
+++ b/app/src/snoozed.rs
@@ -2,20 +2,23 @@ use {
     super::util::format_task,
     chrono::{DateTime, Utc},
     model::TodoList,
-    printing::TodoPrinter,
+    printing::{PrintableAppSuccess, PrintableResult},
 };
 
-pub fn run(
-    list: &TodoList,
-    printer: &mut impl TodoPrinter,
+pub fn run<'list>(
+    list: &'list TodoList,
     now: DateTime<Utc>,
-) -> bool {
-    list.all_tasks()
-        .filter(|&id| {
-            list.get(id)
-                .map(|task| task.start_date > now)
-                .unwrap_or_else(|| false)
-        })
-        .for_each(|id| printer.print_task(&format_task(list, id)));
-    false
+) -> PrintableResult<'list> {
+    Ok(PrintableAppSuccess {
+        tasks: list
+            .all_tasks()
+            .filter(|&id| {
+                list.get(id)
+                    .map(|task| task.start_date > now)
+                    .unwrap_or_else(|| false)
+            })
+            .map(|id| format_task(list, id))
+            .collect(),
+        ..Default::default()
+    })
 }

--- a/app/src/testing.rs
+++ b/app/src/testing.rs
@@ -29,11 +29,16 @@ impl<'a> Default for Fixture<'a> {
 pub struct Validator {
     printer: FakePrinter,
     mutated: bool,
+    cmd: String,
 }
 
 impl Validator {
     pub fn modified(self, expected: bool) -> Self {
-        assert_eq!(self.mutated, expected);
+        assert_eq!(
+            self.mutated, expected,
+            "Incorrect mutation from '{}'; expected {}, got {}",
+            self.cmd, expected, self.mutated
+        );
         self
     }
 
@@ -54,6 +59,10 @@ impl<'a> Fixture<'a> {
             &self.clock,
             options,
         );
-        Validator { printer, mutated }
+        Validator {
+            printer,
+            mutated,
+            cmd: s.to_string(),
+        }
     }
 }

--- a/app/src/testing.rs
+++ b/app/src/testing.rs
@@ -52,13 +52,14 @@ impl<'a> Fixture<'a> {
         let mut printer = FakePrinter::default();
         let options = Options::try_parse_from(s.split(' '))
             .expect("Could not parse args");
+        use printing::Printable;
         let mutated = crate::todo(
             &mut self.list,
-            &mut printer,
             &self.text_editor,
             &self.clock,
             options,
-        );
+        )
+        .print(&mut printer);
         Validator {
             printer,
             mutated,

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -55,7 +55,7 @@ pub fn todo(
         Some(Split(cmd)) => split::run(list, cmd).print(printer),
         Some(Tag(cmd)) => tag::run(list, &cmd).print(printer),
         Some(Top(cmd)) => top::run(list, &cmd).print(printer),
-        Some(Unblock(cmd)) => unblock::run(list, printer, &cmd),
+        Some(Unblock(cmd)) => unblock::run(list, &cmd).print(printer),
         Some(Unsnooze(cmd)) => unsnooze::run(list, printer, &cmd),
         None => status::run(list, now, &status_options(options)).print(printer),
     }

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -45,7 +45,7 @@ pub fn todo(
         Some(Merge(cmd)) => merge::run(list, now, &cmd).print(printer),
         Some(New(cmd)) => new::run(list, printer, now, &cmd),
         Some(Path(cmd)) => path::run(list, &cmd).print(printer),
-        Some(Priority(cmd)) => priority::run(list, printer, &cmd),
+        Some(Priority(cmd)) => priority::run(list, &cmd).print(printer),
         Some(Punt(cmd)) => punt::run(list, printer, &cmd),
         Some(Put(cmd)) => put::run(list, printer, &cmd),
         Some(Restore(cmd)) => restore::run(list, printer, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -52,7 +52,7 @@ pub fn todo(
         Some(Rm(cmd)) => rm::run(list, printer, cmd),
         Some(Snooze(cmd)) => snooze::run(list, now, &cmd).print(printer),
         Some(Snoozed(_)) => snoozed::run(list, now).print(printer),
-        Some(Split(cmd)) => split::run(list, printer, cmd),
+        Some(Split(cmd)) => split::run(list, cmd).print(printer),
         Some(Tag(cmd)) => tag::run(list, printer, &cmd),
         Some(Top(cmd)) => top::run(list, printer, &cmd),
         Some(Unblock(cmd)) => unblock::run(list, printer, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -38,7 +38,7 @@ pub fn todo(
         Some(Check(cmd)) => check::run(list, now, &cmd).print(printer),
         Some(Config(_)) => unimplemented!(),
         Some(Due(cmd)) => due::run(list, printer, now, &cmd),
-        Some(Edit(cmd)) => edit::run(list, printer, text_editor, &cmd),
+        Some(Edit(cmd)) => edit::run(list, text_editor, &cmd).print(printer),
         Some(Find(cmd)) => find::run(list, printer, &cmd),
         Some(Get(cmd)) => get::run(list, printer, &cmd),
         Some(Log) => log::run(list, printer),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -57,6 +57,6 @@ pub fn todo(
         Some(Top(cmd)) => top::run(list, printer, &cmd),
         Some(Unblock(cmd)) => unblock::run(list, printer, &cmd),
         Some(Unsnooze(cmd)) => unsnooze::run(list, printer, &cmd),
-        None => status::run(list, printer, now, &status_options(options)),
+        None => status::run(list, now, &status_options(options)).print(printer),
     }
 }

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -48,7 +48,7 @@ pub fn todo(
         Some(Priority(cmd)) => priority::run(list, &cmd).print(printer),
         Some(Punt(cmd)) => punt::run(list, &cmd).print(printer),
         Some(Put(cmd)) => put::run(list, &cmd).print(printer),
-        Some(Restore(cmd)) => restore::run(list, printer, &cmd),
+        Some(Restore(cmd)) => restore::run(list, &cmd).print(printer),
         Some(Rm(cmd)) => rm::run(list, printer, cmd),
         Some(Snooze(cmd)) => snooze::run(list, printer, now, &cmd),
         Some(Snoozed(_)) => snoozed::run(list, printer, now),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -33,7 +33,7 @@ pub fn todo(
     match options.cmd {
         Some(Block(cmd)) => block::run(list, &cmd).print(printer),
         Some(Bottom(cmd)) => bottom::run(list, &cmd).print(printer),
-        Some(Budget(cmd)) => budget::run(list, printer, &cmd),
+        Some(Budget(cmd)) => budget::run(list, &cmd).print(printer),
         Some(Chain(cmd)) => chain::run(list, printer, &cmd),
         Some(Check(cmd)) => check::run(list, printer, now, &cmd),
         Some(Config(_)) => unimplemented!(),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -39,7 +39,7 @@ pub fn todo(
         Some(Config(_)) => unimplemented!(),
         Some(Due(cmd)) => due::run(list, printer, now, &cmd),
         Some(Edit(cmd)) => edit::run(list, text_editor, &cmd).print(printer),
-        Some(Find(cmd)) => find::run(list, printer, &cmd),
+        Some(Find(cmd)) => find::run(list, &cmd).print(printer),
         Some(Get(cmd)) => get::run(list, printer, &cmd),
         Some(Log) => log::run(list, printer),
         Some(Merge(cmd)) => merge::run(list, printer, now, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -43,7 +43,7 @@ pub fn todo(
         Some(Get(cmd)) => get::run(list, &cmd).print(printer),
         Some(Log) => log::run(list).print(printer),
         Some(Merge(cmd)) => merge::run(list, now, &cmd).print(printer),
-        Some(New(cmd)) => new::run(list, printer, now, &cmd),
+        Some(New(cmd)) => new::run(list, now, &cmd).print(printer),
         Some(Path(cmd)) => path::run(list, &cmd).print(printer),
         Some(Priority(cmd)) => priority::run(list, &cmd).print(printer),
         Some(Punt(cmd)) => punt::run(list, &cmd).print(printer),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -54,7 +54,7 @@ pub fn todo(
         Some(Snoozed(_)) => snoozed::run(list, now).print(printer),
         Some(Split(cmd)) => split::run(list, cmd).print(printer),
         Some(Tag(cmd)) => tag::run(list, &cmd).print(printer),
-        Some(Top(cmd)) => top::run(list, printer, &cmd),
+        Some(Top(cmd)) => top::run(list, &cmd).print(printer),
         Some(Unblock(cmd)) => unblock::run(list, printer, &cmd),
         Some(Unsnooze(cmd)) => unsnooze::run(list, printer, &cmd),
         None => status::run(list, now, &status_options(options)).print(printer),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -37,7 +37,7 @@ pub fn todo(
         Some(Chain(cmd)) => chain::run(list, &cmd).print(printer),
         Some(Check(cmd)) => check::run(list, now, &cmd).print(printer),
         Some(Config(_)) => unimplemented!(),
-        Some(Due(cmd)) => due::run(list, printer, now, &cmd),
+        Some(Due(cmd)) => due::run(list, now, &cmd).print(printer),
         Some(Edit(cmd)) => edit::run(list, text_editor, &cmd).print(printer),
         Some(Find(cmd)) => find::run(list, &cmd).print(printer),
         Some(Get(cmd)) => get::run(list, &cmd).print(printer),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -50,7 +50,7 @@ pub fn todo(
         Some(Put(cmd)) => put::run(list, &cmd).print(printer),
         Some(Restore(cmd)) => restore::run(list, &cmd).print(printer),
         Some(Rm(cmd)) => rm::run(list, printer, cmd),
-        Some(Snooze(cmd)) => snooze::run(list, printer, now, &cmd),
+        Some(Snooze(cmd)) => snooze::run(list, now, &cmd).print(printer),
         Some(Snoozed(_)) => snoozed::run(list, printer, now),
         Some(Split(cmd)) => split::run(list, printer, cmd),
         Some(Tag(cmd)) => tag::run(list, printer, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -51,7 +51,7 @@ pub fn todo(
         Some(Restore(cmd)) => restore::run(list, &cmd).print(printer),
         Some(Rm(cmd)) => rm::run(list, printer, cmd),
         Some(Snooze(cmd)) => snooze::run(list, now, &cmd).print(printer),
-        Some(Snoozed(_)) => snoozed::run(list, printer, now),
+        Some(Snoozed(_)) => snoozed::run(list, now).print(printer),
         Some(Split(cmd)) => split::run(list, printer, cmd),
         Some(Tag(cmd)) => tag::run(list, printer, &cmd),
         Some(Top(cmd)) => top::run(list, printer, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -42,7 +42,7 @@ pub fn todo(
         Some(Find(cmd)) => find::run(list, &cmd).print(printer),
         Some(Get(cmd)) => get::run(list, &cmd).print(printer),
         Some(Log) => log::run(list).print(printer),
-        Some(Merge(cmd)) => merge::run(list, printer, now, &cmd),
+        Some(Merge(cmd)) => merge::run(list, now, &cmd).print(printer),
         Some(New(cmd)) => new::run(list, printer, now, &cmd),
         Some(Path(cmd)) => path::run(list, printer, &cmd),
         Some(Priority(cmd)) => priority::run(list, printer, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -41,7 +41,7 @@ pub fn todo(
         Some(Edit(cmd)) => edit::run(list, text_editor, &cmd).print(printer),
         Some(Find(cmd)) => find::run(list, &cmd).print(printer),
         Some(Get(cmd)) => get::run(list, &cmd).print(printer),
-        Some(Log) => log::run(list, printer),
+        Some(Log) => log::run(list).print(printer),
         Some(Merge(cmd)) => merge::run(list, printer, now, &cmd),
         Some(New(cmd)) => new::run(list, printer, now, &cmd),
         Some(Path(cmd)) => path::run(list, printer, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -32,7 +32,7 @@ pub fn todo(
     let now = clock.now();
     match options.cmd {
         Some(Block(cmd)) => block::run(list, &cmd).print(printer),
-        Some(Bottom(cmd)) => bottom::run(list, printer, &cmd),
+        Some(Bottom(cmd)) => bottom::run(list, &cmd).print(printer),
         Some(Budget(cmd)) => budget::run(list, printer, &cmd),
         Some(Chain(cmd)) => chain::run(list, printer, &cmd),
         Some(Check(cmd)) => check::run(list, printer, now, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -35,7 +35,7 @@ pub fn todo(
         Some(Bottom(cmd)) => bottom::run(list, &cmd).print(printer),
         Some(Budget(cmd)) => budget::run(list, &cmd).print(printer),
         Some(Chain(cmd)) => chain::run(list, &cmd).print(printer),
-        Some(Check(cmd)) => check::run(list, printer, now, &cmd),
+        Some(Check(cmd)) => check::run(list, now, &cmd).print(printer),
         Some(Config(_)) => unimplemented!(),
         Some(Due(cmd)) => due::run(list, printer, now, &cmd),
         Some(Edit(cmd)) => edit::run(list, printer, text_editor, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -46,7 +46,7 @@ pub fn todo(
         Some(New(cmd)) => new::run(list, printer, now, &cmd),
         Some(Path(cmd)) => path::run(list, &cmd).print(printer),
         Some(Priority(cmd)) => priority::run(list, &cmd).print(printer),
-        Some(Punt(cmd)) => punt::run(list, printer, &cmd),
+        Some(Punt(cmd)) => punt::run(list, &cmd).print(printer),
         Some(Put(cmd)) => put::run(list, printer, &cmd),
         Some(Restore(cmd)) => restore::run(list, printer, &cmd),
         Some(Rm(cmd)) => rm::run(list, printer, cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -34,7 +34,7 @@ pub fn todo(
         Some(Block(cmd)) => block::run(list, &cmd).print(printer),
         Some(Bottom(cmd)) => bottom::run(list, &cmd).print(printer),
         Some(Budget(cmd)) => budget::run(list, &cmd).print(printer),
-        Some(Chain(cmd)) => chain::run(list, printer, &cmd),
+        Some(Chain(cmd)) => chain::run(list, &cmd).print(printer),
         Some(Check(cmd)) => check::run(list, printer, now, &cmd),
         Some(Config(_)) => unimplemented!(),
         Some(Due(cmd)) => due::run(list, printer, now, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -53,7 +53,7 @@ pub fn todo(
         Some(Snooze(cmd)) => snooze::run(list, now, &cmd).print(printer),
         Some(Snoozed(_)) => snoozed::run(list, now).print(printer),
         Some(Split(cmd)) => split::run(list, cmd).print(printer),
-        Some(Tag(cmd)) => tag::run(list, printer, &cmd),
+        Some(Tag(cmd)) => tag::run(list, &cmd).print(printer),
         Some(Top(cmd)) => top::run(list, printer, &cmd),
         Some(Unblock(cmd)) => unblock::run(list, printer, &cmd),
         Some(Unsnooze(cmd)) => unsnooze::run(list, printer, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -28,9 +28,10 @@ pub fn todo(
     options: Options,
 ) -> bool {
     use self::SubCommand::*;
+    use printing::Printable;
     let now = clock.now();
     match options.cmd {
-        Some(Block(cmd)) => block::run(list, printer, &cmd),
+        Some(Block(cmd)) => block::run(list, &cmd).print(printer),
         Some(Bottom(cmd)) => bottom::run(list, printer, &cmd),
         Some(Budget(cmd)) => budget::run(list, printer, &cmd),
         Some(Chain(cmd)) => chain::run(list, printer, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -7,7 +7,7 @@ use {
     cli::{Options, SubCommand},
     clock::Clock,
     model::TodoList,
-    printing::TodoPrinter,
+    printing::PrintableResult,
     text_editing::TextEditor,
 };
 
@@ -20,43 +20,41 @@ fn status_options(options: Options) -> status::Status {
 
 /// Runs the 'todo' command line application. Returns whether the list was
 /// modified; if so, the caller should save the list.
-pub fn todo(
-    list: &mut TodoList,
-    printer: &mut impl TodoPrinter,
+pub fn todo<'list>(
+    list: &'list mut TodoList,
     text_editor: &impl TextEditor,
     clock: &impl Clock,
     options: Options,
-) -> bool {
+) -> PrintableResult<'list> {
     use self::SubCommand::*;
-    use printing::Printable;
     let now = clock.now();
     match options.cmd {
-        Some(Block(cmd)) => block::run(list, &cmd).print(printer),
-        Some(Bottom(cmd)) => bottom::run(list, &cmd).print(printer),
-        Some(Budget(cmd)) => budget::run(list, &cmd).print(printer),
-        Some(Chain(cmd)) => chain::run(list, &cmd).print(printer),
-        Some(Check(cmd)) => check::run(list, now, &cmd).print(printer),
+        Some(Block(cmd)) => block::run(list, &cmd),
+        Some(Bottom(cmd)) => bottom::run(list, &cmd),
+        Some(Budget(cmd)) => budget::run(list, &cmd),
+        Some(Chain(cmd)) => chain::run(list, &cmd),
+        Some(Check(cmd)) => check::run(list, now, &cmd),
         Some(Config(_)) => unimplemented!(),
-        Some(Due(cmd)) => due::run(list, now, &cmd).print(printer),
-        Some(Edit(cmd)) => edit::run(list, text_editor, &cmd).print(printer),
-        Some(Find(cmd)) => find::run(list, &cmd).print(printer),
-        Some(Get(cmd)) => get::run(list, &cmd).print(printer),
-        Some(Log) => log::run(list).print(printer),
-        Some(Merge(cmd)) => merge::run(list, now, &cmd).print(printer),
-        Some(New(cmd)) => new::run(list, now, &cmd).print(printer),
-        Some(Path(cmd)) => path::run(list, &cmd).print(printer),
-        Some(Priority(cmd)) => priority::run(list, &cmd).print(printer),
-        Some(Punt(cmd)) => punt::run(list, &cmd).print(printer),
-        Some(Put(cmd)) => put::run(list, &cmd).print(printer),
-        Some(Restore(cmd)) => restore::run(list, &cmd).print(printer),
-        Some(Rm(cmd)) => rm::run(list, cmd).print(printer),
-        Some(Snooze(cmd)) => snooze::run(list, now, &cmd).print(printer),
-        Some(Snoozed(_)) => snoozed::run(list, now).print(printer),
-        Some(Split(cmd)) => split::run(list, cmd).print(printer),
-        Some(Tag(cmd)) => tag::run(list, &cmd).print(printer),
-        Some(Top(cmd)) => top::run(list, &cmd).print(printer),
-        Some(Unblock(cmd)) => unblock::run(list, &cmd).print(printer),
-        Some(Unsnooze(cmd)) => unsnooze::run(list, &cmd).print(printer),
-        None => status::run(list, now, &status_options(options)).print(printer),
+        Some(Due(cmd)) => due::run(list, now, &cmd),
+        Some(Edit(cmd)) => edit::run(list, text_editor, &cmd),
+        Some(Find(cmd)) => find::run(list, &cmd),
+        Some(Get(cmd)) => get::run(list, &cmd),
+        Some(Log) => log::run(list),
+        Some(Merge(cmd)) => merge::run(list, now, &cmd),
+        Some(New(cmd)) => new::run(list, now, &cmd),
+        Some(Path(cmd)) => path::run(list, &cmd),
+        Some(Priority(cmd)) => priority::run(list, &cmd),
+        Some(Punt(cmd)) => punt::run(list, &cmd),
+        Some(Put(cmd)) => put::run(list, &cmd),
+        Some(Restore(cmd)) => restore::run(list, &cmd),
+        Some(Rm(cmd)) => rm::run(list, cmd),
+        Some(Snooze(cmd)) => snooze::run(list, now, &cmd),
+        Some(Snoozed(_)) => snoozed::run(list, now),
+        Some(Split(cmd)) => split::run(list, cmd),
+        Some(Tag(cmd)) => tag::run(list, &cmd),
+        Some(Top(cmd)) => top::run(list, &cmd),
+        Some(Unblock(cmd)) => unblock::run(list, &cmd),
+        Some(Unsnooze(cmd)) => unsnooze::run(list, &cmd),
+        None => status::run(list, now, &status_options(options)),
     }
 }

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -56,7 +56,7 @@ pub fn todo(
         Some(Tag(cmd)) => tag::run(list, &cmd).print(printer),
         Some(Top(cmd)) => top::run(list, &cmd).print(printer),
         Some(Unblock(cmd)) => unblock::run(list, &cmd).print(printer),
-        Some(Unsnooze(cmd)) => unsnooze::run(list, printer, &cmd),
+        Some(Unsnooze(cmd)) => unsnooze::run(list, &cmd).print(printer),
         None => status::run(list, now, &status_options(options)).print(printer),
     }
 }

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -44,7 +44,7 @@ pub fn todo(
         Some(Log) => log::run(list).print(printer),
         Some(Merge(cmd)) => merge::run(list, now, &cmd).print(printer),
         Some(New(cmd)) => new::run(list, printer, now, &cmd),
-        Some(Path(cmd)) => path::run(list, printer, &cmd),
+        Some(Path(cmd)) => path::run(list, &cmd).print(printer),
         Some(Priority(cmd)) => priority::run(list, printer, &cmd),
         Some(Punt(cmd)) => punt::run(list, printer, &cmd),
         Some(Put(cmd)) => put::run(list, printer, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -47,7 +47,7 @@ pub fn todo(
         Some(Path(cmd)) => path::run(list, &cmd).print(printer),
         Some(Priority(cmd)) => priority::run(list, &cmd).print(printer),
         Some(Punt(cmd)) => punt::run(list, &cmd).print(printer),
-        Some(Put(cmd)) => put::run(list, printer, &cmd),
+        Some(Put(cmd)) => put::run(list, &cmd).print(printer),
         Some(Restore(cmd)) => restore::run(list, printer, &cmd),
         Some(Rm(cmd)) => rm::run(list, printer, cmd),
         Some(Snooze(cmd)) => snooze::run(list, printer, now, &cmd),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -49,7 +49,7 @@ pub fn todo(
         Some(Punt(cmd)) => punt::run(list, &cmd).print(printer),
         Some(Put(cmd)) => put::run(list, &cmd).print(printer),
         Some(Restore(cmd)) => restore::run(list, &cmd).print(printer),
-        Some(Rm(cmd)) => rm::run(list, printer, cmd),
+        Some(Rm(cmd)) => rm::run(list, cmd).print(printer),
         Some(Snooze(cmd)) => snooze::run(list, now, &cmd).print(printer),
         Some(Snoozed(_)) => snoozed::run(list, now).print(printer),
         Some(Split(cmd)) => split::run(list, cmd).print(printer),

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -40,7 +40,7 @@ pub fn todo(
         Some(Due(cmd)) => due::run(list, printer, now, &cmd),
         Some(Edit(cmd)) => edit::run(list, text_editor, &cmd).print(printer),
         Some(Find(cmd)) => find::run(list, &cmd).print(printer),
-        Some(Get(cmd)) => get::run(list, printer, &cmd),
+        Some(Get(cmd)) => get::run(list, &cmd).print(printer),
         Some(Log) => log::run(list, printer),
         Some(Merge(cmd)) => merge::run(list, printer, now, &cmd),
         Some(New(cmd)) => new::run(list, printer, now, &cmd),

--- a/app/src/unblock.rs
+++ b/app/src/unblock.rs
@@ -93,5 +93,6 @@ pub fn run<'list>(
         tasks: tasks_to_print,
         warnings,
         mutated,
+        ..Default::default()
     })
 }

--- a/app/src/unsnooze.rs
+++ b/app/src/unsnooze.rs
@@ -65,5 +65,6 @@ pub fn run<'list>(
         tasks: formatted_tasks_to_print,
         warnings: formatted_warnings,
         mutated,
+        ..Default::default()
     })
 }

--- a/app/src/util.rs
+++ b/app/src/util.rs
@@ -4,7 +4,6 @@ use {
     model::{DurationInSeconds, TaskId, TaskSet, TaskStatus, TodoList},
     printing::{
         BriefPrintableTask, Plicit, PrintableError, PrintableTask, Status,
-        TodoPrinter,
     },
     std::convert::TryFrom,
 };
@@ -227,14 +226,6 @@ pub fn parse_due_date(
     }
 }
 
-pub fn parse_due_date_or_print_error(
-    now: DateTime<Utc>,
-    due_date_vec: &[String],
-    printer: &mut impl TodoPrinter,
-) -> Result<Option<DateTime<Utc>>, ()> {
-    parse_due_date(now, due_date_vec).map_err(|e| printer.print_error(&e))
-}
-
 pub fn parse_budget(
     chunks: &[String],
 ) -> Result<DurationInSeconds, PrintableError> {
@@ -260,13 +251,6 @@ pub fn parse_budget(
     }
 }
 
-pub fn parse_budget_or_print_error(
-    budget_vec: &[String],
-    printer: &mut impl TodoPrinter,
-) -> Result<DurationInSeconds, ()> {
-    parse_budget(budget_vec).map_err(|e| printer.print_error(&e))
-}
-
 pub fn parse_snooze_date(
     now: DateTime<Utc>,
     chunks: &[String],
@@ -286,12 +270,4 @@ pub fn parse_snooze_date(
             cannot_parse: date_string.to_string(),
         }),
     }
-}
-
-pub fn parse_snooze_date_or_print_error(
-    now: DateTime<Utc>,
-    snooze_date_vec: &[String],
-    printer: &mut impl TodoPrinter,
-) -> Result<Option<DateTime<Utc>>, ()> {
-    parse_snooze_date(now, snooze_date_vec).map_err(|e| printer.print_error(&e))
 }

--- a/app/src/util.rs
+++ b/app/src/util.rs
@@ -267,12 +267,11 @@ pub fn parse_budget_or_print_error(
     parse_budget(budget_vec).map_err(|e| printer.print_error(&e))
 }
 
-pub fn parse_snooze_date_or_print_error(
+pub fn parse_snooze_date(
     now: DateTime<Utc>,
-    snooze_date_vec: &[String],
-    printer: &mut impl TodoPrinter,
-) -> Result<Option<DateTime<Utc>>, ()> {
-    let date_string = snooze_date_vec.join(" ");
+    chunks: &[String],
+) -> Result<Option<DateTime<Utc>>, PrintableError> {
+    let date_string = chunks.join(" ");
     if date_string.is_empty() || date_string.is_empty() {
         return Ok(None);
     }
@@ -283,11 +282,16 @@ pub fn parse_snooze_date_or_print_error(
         ::time_format::Snap::ToStart,
     ) {
         Ok(snooze_date) => Ok(Some(snooze_date.with_timezone(&Utc))),
-        Err(_) => {
-            printer.print_error(&PrintableError::CannotParseDueDate {
-                cannot_parse: date_string.to_string(),
-            });
-            Err(())
-        }
+        Err(_) => Err(PrintableError::CannotParseDueDate {
+            cannot_parse: date_string.to_string(),
+        }),
     }
+}
+
+pub fn parse_snooze_date_or_print_error(
+    now: DateTime<Utc>,
+    snooze_date_vec: &[String],
+    printer: &mut impl TodoPrinter,
+) -> Result<Option<DateTime<Utc>>, ()> {
+    parse_snooze_date(now, snooze_date_vec).map_err(|e| printer.print_error(&e))
 }

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -71,6 +71,7 @@ fn main() -> TodoResult {
         Err(_) => model::TodoList::default(),
     };
 
+    use printing::Printable;
     let mutated = if let Some((term_width, _)) = term_size::dimensions_stdout()
     {
         let mut printer = SimpleTodoPrinter {
@@ -87,19 +88,19 @@ fn main() -> TodoResult {
         };
         app::todo(
             &mut model,
-            &mut printer,
             &ScrawlTextEditor(&config.text_editor_cmd),
             &SystemClock,
             options,
         )
+        .print(&mut printer)
     } else {
         app::todo(
             &mut model,
-            &mut ScriptingTodoPrinter,
             &FakeTextEditor::no_user_output(),
             &SystemClock,
             options,
         )
+        .print(&mut ScriptingTodoPrinter)
     };
     if mutated {
         let file = File::create(&data_path)?;

--- a/printing/src/format_util.rs
+++ b/printing/src/format_util.rs
@@ -49,7 +49,6 @@ pub fn format_number(number: i32, status: Status) -> String {
         Status::Complete => Color::Green.normal(),
         Status::Incomplete => Color::Yellow.normal(),
         Status::Blocked => Color::Red.normal(),
-        Status::Removed => Color::White.normal(),
     };
     let mut indexing = number.to_string();
     indexing.push(')');

--- a/printing/src/lib.rs
+++ b/printing/src/lib.rs
@@ -28,6 +28,7 @@ mod simple_todo_printer_test;
 #[cfg(test)]
 mod testing_test;
 
+#[derive(Default)]
 pub struct PrintableAppSuccess<'list> {
     pub warnings: Vec<PrintableWarning>,
     pub tasks: Vec<PrintableTask<'list>>,

--- a/printing/src/lib.rs
+++ b/printing/src/lib.rs
@@ -27,3 +27,42 @@ mod printable_warning_test;
 mod simple_todo_printer_test;
 #[cfg(test)]
 mod testing_test;
+
+pub struct PrintableAppSuccess<'list> {
+    pub warnings: Vec<PrintableWarning>,
+    pub tasks: Vec<PrintableTask<'list>>,
+    pub mutated: bool,
+}
+
+pub type PrintableResult<'list> =
+    Result<PrintableAppSuccess<'list>, Vec<PrintableError>>;
+
+pub trait Printable {
+    fn print(&self, printer: &mut impl TodoPrinter) -> bool;
+}
+
+impl Printable for PrintableResult<'_> {
+    fn print(&self, printer: &mut impl TodoPrinter) -> bool {
+        match self {
+            Self::Ok(PrintableAppSuccess {
+                warnings,
+                tasks,
+                mutated,
+            }) => {
+                for warning in warnings {
+                    printer.print_warning(warning);
+                }
+                for task in tasks {
+                    printer.print_task(task);
+                }
+                *mutated
+            }
+            Self::Err(errors) => {
+                for error in errors {
+                    printer.print_error(error);
+                }
+                false
+            }
+        }
+    }
+}

--- a/printing/src/lib.rs
+++ b/printing/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod brief_printable_task;
 mod format_util;
 pub mod printable_error;
+pub mod printable_info;
 pub mod printable_task;
 pub mod printable_warning;
 pub mod scripting_todo_printer;
@@ -10,6 +11,7 @@ pub mod todo_printer;
 
 pub use self::brief_printable_task::*;
 pub use self::printable_error::*;
+pub use self::printable_info::*;
 pub use self::printable_task::*;
 pub use self::printable_warning::*;
 pub use self::scripting_todo_printer::*;
@@ -19,6 +21,8 @@ pub use self::todo_printer::*;
 
 #[cfg(test)]
 mod printable_error_test;
+#[cfg(test)]
+mod printable_info_test;
 #[cfg(test)]
 mod printable_task_test;
 #[cfg(test)]
@@ -31,6 +35,7 @@ mod testing_test;
 #[derive(Default)]
 pub struct PrintableAppSuccess<'list> {
     pub warnings: Vec<PrintableWarning>,
+    pub infos: Vec<PrintableInfo>,
     pub tasks: Vec<PrintableTask<'list>>,
     pub mutated: bool,
 }
@@ -47,11 +52,15 @@ impl Printable for PrintableResult<'_> {
         match self {
             Self::Ok(PrintableAppSuccess {
                 warnings,
+                infos,
                 tasks,
                 mutated,
             }) => {
                 for warning in warnings {
                     printer.print_warning(warning);
+                }
+                for info in infos {
+                    printer.print_info(info);
                 }
                 for task in tasks {
                     printer.print_task(task);

--- a/printing/src/printable_info.rs
+++ b/printing/src/printable_info.rs
@@ -1,0 +1,19 @@
+use ansi_term::Color;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+
+pub enum PrintableInfo {
+    Removed { desc: String },
+}
+
+impl Display for PrintableInfo {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        use self::PrintableInfo::*;
+        write!(f, "{}: ", Color::White.bold().dimmed().paint("info"))?;
+        match self {
+            Removed { desc } => write!(f, "Removed \"{}\"", desc),
+        }
+    }
+}

--- a/printing/src/printable_info_test.rs
+++ b/printing/src/printable_info_test.rs
@@ -1,0 +1,12 @@
+use crate::PrintableInfo::*;
+
+#[test]
+fn display_info_removed() {
+    let info = Removed {
+        desc: "foo".to_string(),
+    };
+    assert_eq!(
+        format!("{}", info),
+        "\u{1b}[1;2;37minfo\u{1b}[0m: Removed \"foo\""
+    );
+}

--- a/printing/src/printable_task.rs
+++ b/printing/src/printable_task.rs
@@ -12,7 +12,6 @@ pub enum Status {
     Incomplete,
     Complete,
     Blocked,
-    Removed,
 }
 
 impl Default for Status {

--- a/printing/src/scripting_todo_printer.rs
+++ b/printing/src/scripting_todo_printer.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{PrintableError, PrintableTask, PrintableWarning, TodoPrinter},
+    crate::{
+        PrintableError, PrintableInfo, PrintableTask, PrintableWarning,
+        TodoPrinter,
+    },
     std::io::Write,
 };
 
@@ -8,6 +11,10 @@ pub struct ScriptingTodoPrinter;
 impl TodoPrinter for ScriptingTodoPrinter {
     fn print_task(&mut self, task: &PrintableTask) {
         writeln!(std::io::stdout(), "{}", task.number).unwrap_or_default();
+    }
+
+    fn print_info(&mut self, info: &PrintableInfo) {
+        writeln!(std::io::stderr(), "{}", info).unwrap_or_default();
     }
 
     fn print_warning(&mut self, warning: &PrintableWarning) {

--- a/printing/src/simple_todo_printer.rs
+++ b/printing/src/simple_todo_printer.rs
@@ -4,8 +4,8 @@
 
 use {
     crate::{
-        format_util::format_number, Plicit, PrintableError, PrintableTask,
-        PrintableWarning, TodoPrinter,
+        format_util::format_number, Plicit, PrintableError, PrintableInfo,
+        PrintableTask, PrintableWarning, TodoPrinter,
     },
     ansi_term::{Color, Style},
     chrono::{DateTime, Duration, Local, Utc},
@@ -300,6 +300,9 @@ impl<Out: Write> TodoPrinter for SimpleTodoPrinter<Out> {
             }
         )
         .unwrap_or_default();
+    }
+    fn print_info(&mut self, info: &PrintableInfo) {
+        writeln!(self.out, "{}", info).unwrap_or_default();
     }
     fn print_warning(&mut self, warning: &PrintableWarning) {
         writeln!(self.out, "{}", warning).unwrap_or_default();

--- a/printing/src/simple_todo_printer_test.rs
+++ b/printing/src/simple_todo_printer_test.rs
@@ -2,8 +2,9 @@
 
 use {
     crate::{
-        BriefPrintableTask, PrintableError, PrintableTask, PrintableWarning,
-        PrintingContext, SimpleTodoPrinter, Status::*, TodoPrinter,
+        BriefPrintableTask, PrintableError, PrintableInfo, PrintableTask,
+        PrintableWarning, PrintingContext, SimpleTodoPrinter, Status::*,
+        TodoPrinter,
     },
     lookup_key::Key,
     std::io::Write,
@@ -98,4 +99,12 @@ fn print_error_to_broken_pipe() {
         "a".to_string(),
         "b".to_string(),
     )));
+}
+
+#[test]
+fn print_info_to_broken_pipe() {
+    let mut printer = create_printer_to_broken_pipe();
+    printer.print_info(&PrintableInfo::Removed {
+        desc: "a".to_string(),
+    });
 }

--- a/printing/src/testing.rs
+++ b/printing/src/testing.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        Action, LogDate, Plicit, PrintableError, PrintableTask,
+        Action, LogDate, Plicit, PrintableError, PrintableInfo, PrintableTask,
         PrintableWarning, Status, TodoPrinter,
     },
     chrono::{DateTime, Duration, Local, Utc},
@@ -24,6 +24,7 @@ struct PrintedTaskInfo {
 #[derive(Debug)]
 enum PrintedItem {
     Task(PrintedTaskInfo),
+    Info(PrintableInfo),
     Warning(PrintableWarning),
     Error(PrintableError),
 }
@@ -237,6 +238,20 @@ impl<'a> Validation<'a> {
         self
     }
 
+    pub fn printed_info(
+        mut self,
+        expected: &'a PrintableInfo,
+    ) -> Validation<'a> {
+        let item = self.pop(expected);
+        match &item {
+            PrintedItem::Info(ref actual) => {
+                assert_eq!(actual, expected, "Unexpected info")
+            }
+            _ => panic!("Expected\n{:#?}\n... but got\n{:#?}", expected, item),
+        };
+        self
+    }
+
     pub fn printed_warning(
         mut self,
         expected: &'a PrintableWarning,
@@ -299,6 +314,10 @@ impl TodoPrinter for FakePrinter {
                 .map(|tag| tag.to_string())
                 .collect(),
         }));
+    }
+
+    fn print_info(&mut self, info: &PrintableInfo) {
+        self.record.push(PrintedItem::Info(info.clone()));
     }
 
     fn print_warning(&mut self, warning: &PrintableWarning) {

--- a/printing/src/testing_test.rs
+++ b/printing/src/testing_test.rs
@@ -3,8 +3,8 @@
 use {
     crate::{
         Action::*, BriefPrintableTask, FakePrinter, LogDate::*, Plicit::*,
-        PrintableError, PrintableTask, PrintableWarning, Status::*,
-        TodoPrinter,
+        PrintableError, PrintableInfo, PrintableTask, PrintableWarning,
+        Status::*, TodoPrinter,
     },
     lookup_key::Key,
     testing::ymdhms,
@@ -32,6 +32,16 @@ fn validate_multiple_tasks() {
         .printed_task(&PrintableTask::new("b", 2, Incomplete))
         .printed_task(&PrintableTask::new("c", 3, Incomplete))
         .end();
+}
+
+#[test]
+fn validate_info() {
+    let mut printer = FakePrinter::default();
+    let info = PrintableInfo::Removed {
+        desc: "a".to_string(),
+    };
+    printer.print_info(&info);
+    printer.validate().printed_info(&info).end();
 }
 
 #[test]
@@ -115,6 +125,20 @@ fn fail_validation_on_incorrect_action_exact() {
         .validate()
         .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
         .end();
+}
+
+#[test]
+#[should_panic(expected = "Unexpected info")]
+fn fail_vlaidation_on_wrong_info() {
+    let mut printer = FakePrinter::default();
+    let info1 = PrintableInfo::Removed {
+        desc: "a".to_string(),
+    };
+    let info2 = PrintableInfo::Removed {
+        desc: "b".to_string(),
+    };
+    printer.print_info(&info1);
+    printer.validate().printed_info(&info2).end();
 }
 
 #[test]

--- a/printing/src/todo_printer.rs
+++ b/printing/src/todo_printer.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub trait TodoPrinter {
     fn print_task(&mut self, task: &PrintableTask);
+    fn print_info(&mut self, info: &PrintableInfo);
     fn print_warning(&mut self, warning: &PrintableWarning);
     fn print_error(&mut self, error: &PrintableError);
 }


### PR DESCRIPTION
Instead of printing to a mutable TodoPrinter, apps, now return a data structure telling the caller what to print, and the caller decides how. This allows compile-time enforcement of invariants like:

* don't mutate if errors occur
* always print warnings before tasks
* print all tasks together