### PR TITLE
Allow --by flag as a new preposition.

### DIFF
--- a/app/src/new_test.rs
+++ b/app/src/new_test.rs
@@ -259,6 +259,75 @@ fn new_one_after_three() {
 }
 
 #[test]
+fn new_one_by_one() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo new d --by b")
+        .modified(true)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
+        .printed_task(&PrintableTask::new("c", 4, Blocked))
+        .end();
+}
+
+#[test]
+fn new_three_by_one() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo new d e f --by b")
+        .modified(true)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
+        .printed_task(&PrintableTask::new("e", 4, Blocked).action(New))
+        .printed_task(&PrintableTask::new("f", 5, Blocked).action(New))
+        .printed_task(&PrintableTask::new("c", 6, Blocked))
+        .end();
+}
+
+#[test]
+fn new_one_by_three() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c");
+    fix.test("todo new d -p a b c");
+    fix.test("todo new e --by a b c")
+        .modified(true)
+        .validate()
+        .printed_task(&PrintableTask::new("e", 4, Incomplete).action(New))
+        .printed_task(&PrintableTask::new("d", 5, Blocked))
+        .end();
+}
+
+#[test]
+fn new_one_by_one_with_chain() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo new d --by b --chain")
+        .modified(true)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
+        .printed_task(&PrintableTask::new("c", 4, Blocked))
+        .end();
+}
+
+#[test]
+fn new_three_by_one_with_chain() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo new d e f --by b --chain")
+        .modified(true)
+        .validate()
+        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
+        .printed_task(&PrintableTask::new("e", 4, Blocked).action(New))
+        .printed_task(&PrintableTask::new("f", 5, Blocked).action(New))
+        .printed_task(&PrintableTask::new("c", 6, Blocked))
+        .end();
+}
+
+#[test]
 fn print_warning_on_cycle() {
     let mut fix = Fixture::default();
     fix.test("todo new a b --chain");

--- a/app/src/put.rs
+++ b/app/src/put.rs
@@ -26,6 +26,7 @@ pub fn run<'list>(
     let tasks_to_put = lookup_tasks(list, &cmd.keys);
     let before = lookup_tasks(list, &cmd.preposition.before);
     let after = lookup_tasks(list, &cmd.preposition.after);
+    let by = lookup_tasks(list, &cmd.preposition.by);
     let include_done = should_include_done(
         cmd.include_done,
         list,
@@ -37,8 +38,14 @@ pub fn run<'list>(
     let after_adeps: TaskSet = after
         .iter_unsorted()
         .fold(TaskSet::default(), |so_far, id| so_far | list.adeps(id));
-    let tasks_to_block_on = after | before_deps;
-    let tasks_to_block = before | after_adeps;
+    let (by_deps, by_adeps): (TaskSet, TaskSet) = by.iter_unsorted().fold(
+        (TaskSet::default(), TaskSet::default()),
+        |(so_far_deps, so_far_adeps), id| {
+            (so_far_deps | list.deps(id), so_far_adeps | list.adeps(id))
+        },
+    );
+    let tasks_to_block_on = after | before_deps | by_deps;
+    let tasks_to_block = before | after_adeps | by_adeps;
     let mut mutated = false;
 
     let mut blocked_tasks = HashSet::new();

--- a/app/src/testing.rs
+++ b/app/src/testing.rs
@@ -6,12 +6,12 @@ use {
     cli::Options,
     clock::FakeClock,
     model::TodoList,
+    pretty_assertions::assert_eq,
     printing::{
         Action, LogDate, Plicit, PrintableError, PrintableInfo, PrintableTask,
         PrintableWarning, Status, TodoPrinter,
     },
     text_editing::FakeTextEditor,
-    pretty_assertions::assert_eq,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -38,6 +38,7 @@ enum PrintedItem {
 }
 
 pub struct Validation<'a> {
+    cmd: &'a str,
     actual: &'a Vec<PrintedItem>,
     expected: Vec<PrintedItem>,
 }
@@ -93,7 +94,11 @@ impl<'a> Validation<'a> {
     }
 
     pub fn end(self) {
-        assert_eq!(self.actual, &self.expected);
+        let cmd = self.cmd;
+        assert_eq!(
+            &self.expected, self.actual,
+            "Unexpected output from '{cmd}' (left: expected, right: actual)"
+        );
     }
 }
 
@@ -154,6 +159,7 @@ impl Validator {
 
     pub fn validate(&mut self) -> Validation<'_> {
         Validation {
+            cmd: &self.cmd,
             actual: &mut self.record,
             expected: Vec::new(),
         }

--- a/cli/src/subcommands/new.rs
+++ b/cli/src/subcommands/new.rs
@@ -38,6 +38,12 @@ pub struct New {
     #[arg(long, short = 'A', value_name = "keys", num_args = 1..)]
     pub after: Vec<Key>,
 
+    /// Put the new tasks 'by' these tasks.
+    /// 
+    /// The new tasks will have the same deps and adeps as these tasks.
+    #[arg(long, short = 'Y', value_name = "keys", num_args = 1..)]
+    pub by: Vec<Key>,
+
     /// Put the new tasks in a blocking sequence.
     ///
     /// For example, if you do:

--- a/cli/src/subcommands/new_test.rs
+++ b/cli/src/subcommands/new_test.rs
@@ -13,6 +13,7 @@ fn new_missing_keys() {
     expect_error("todo new a -p");
     expect_error("todo new a --before");
     expect_error("todo new a --after");
+    expect_error("todo new a --by");
     expect_error("todo new a --due");
     expect_error("todo new a --budget");
     expect_error("todo new a --snooze");
@@ -133,6 +134,62 @@ fn new_before_after_short() {
             desc: vec!["c".to_string()],
             before: vec![ByName("a".to_string())],
             after: vec![ByName("b".to_string())],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn new_by_long() {
+    expect_parses_into(
+        "todo new c --by d",
+        SubCommand::New(New {
+            desc: vec!["c".to_string()],
+            by: vec![ByName("d".to_string())],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn new_by_long_many() {
+    expect_parses_into(
+        "todo new a b c --by d e f",
+        SubCommand::New(New {
+            desc: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            by: vec![
+                ByName("d".to_string()),
+                ByName("e".to_string()),
+                ByName("f".to_string()),
+            ],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn new_by_short() {
+    expect_parses_into(
+        "todo new c -Y d",
+        SubCommand::New(New {
+            desc: vec!["c".to_string()],
+            by: vec![ByName("d".to_string())],
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn new_by_short_many() {
+    expect_parses_into(
+        "todo new a b c -Y x y z",
+        SubCommand::New(New {
+            desc: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            by: vec![
+                ByName("x".to_string()),
+                ByName("y".to_string()),
+                ByName("z".to_string()),
+            ],
             ..Default::default()
         }),
     );

--- a/cli/src/subcommands/put.rs
+++ b/cli/src/subcommands/put.rs
@@ -1,6 +1,6 @@
 use {clap::Parser, lookup_key::Key};
 
-#[derive(Debug, PartialEq, Eq, Parser)]
+#[derive(Debug, Default, PartialEq, Eq, Parser)]
 pub struct Prepositions {
     /// Put the selected tasks before these tasks.
     #[arg(long, short = 'B', num_args = 1..)]
@@ -8,6 +8,11 @@ pub struct Prepositions {
     /// Put the selected tasks after these tasks.
     #[arg(long, short = 'A', num_args = 1..)]
     pub after: Vec<Key>,
+    /// Put the selected tasks 'by' these tasks.
+    /// 
+    /// The selected tasks will have the same deps and adeps as these tasks.
+    #[arg(long, short = 'Y', num_args = 1..)]
+    pub by: Vec<Key>,
 }
 
 /// Puts tasks before or after other tasks.
@@ -29,6 +34,13 @@ pub struct Prepositions {
 /// If you put task "t" after b, the result is:
 ///
 ///   a <- b <- t <- c
+/// 
+/// If you put task 't' by b, the result is:
+///
+///   a <- (b, t) <- c
+/// 
+/// ... where (b, t) represents two tasks, both of which depend on a and are
+/// depended on by c.
 #[derive(Debug, PartialEq, Eq, Parser)]
 #[command(allow_negative_numbers(true), verbatim_doc_comment)]
 pub struct Put {

--- a/cli/src/subcommands/put_test.rs
+++ b/cli/src/subcommands/put_test.rs
@@ -27,7 +27,7 @@ fn put_one_before() {
             keys: vec![ByName("a".to_string())],
             preposition: Prepositions {
                 before: vec![ByName("b".to_string())],
-                after: vec![],
+                ..Default::default()
             },
             include_done: false,
         }),
@@ -42,7 +42,7 @@ fn put_one_before_short() {
             keys: vec![ByName("a".to_string())],
             preposition: Prepositions {
                 before: vec![ByName("b".to_string())],
-                after: vec![],
+                ..Default::default()
             },
             include_done: false,
         }),
@@ -56,8 +56,8 @@ fn put_one_after() {
         SubCommand::Put(Put {
             keys: vec![ByName("a".to_string())],
             preposition: Prepositions {
-                before: vec![],
                 after: vec![ByName("b".to_string())],
+                ..Default::default()
             },
             include_done: false,
         }),
@@ -71,8 +71,8 @@ fn put_one_after_short() {
         SubCommand::Put(Put {
             keys: vec![ByName("a".to_string())],
             preposition: Prepositions {
-                before: vec![],
                 after: vec![ByName("b".to_string())],
+                ..Default::default()
             },
             include_done: false,
         }),
@@ -100,6 +100,7 @@ fn put_multiple_before_and_after() {
                     ByName("h".to_string()),
                     ByName("i".to_string()),
                 ],
+                ..Default::default()
             },
             include_done: false,
         }),
@@ -114,7 +115,7 @@ fn put_include_done_long() {
             keys: vec![ByName("a".to_string())],
             preposition: Prepositions {
                 before: vec![ByName("b".to_string())],
-                after: vec![],
+                ..Default::default()
             },
             include_done: true,
         }),
@@ -129,9 +130,49 @@ fn put_include_done_short() {
             keys: vec![ByName("a".to_string())],
             preposition: Prepositions {
                 before: vec![ByName("b".to_string())],
-                after: vec![],
+                ..Default::default()
             },
             include_done: true,
+        }),
+    );
+}
+
+#[test]
+fn put_by_long() {
+    expect_parses_into(
+        "todo put a --by b c",
+        SubCommand::Put(Put {
+            keys: vec![
+                ByName("a".to_string()),
+            ],
+            preposition: Prepositions {
+                by: vec![
+                    ByName("b".to_string()),
+                    ByName("c".to_string()),
+                ],
+                ..Default::default()
+            },
+            include_done: false,
+        }),
+    );
+}
+
+#[test]
+fn put_by_short() {
+    expect_parses_into(
+        "todo put a -Y b c",
+        SubCommand::Put(Put {
+            keys: vec![
+                ByName("a".to_string()),
+            ],
+            preposition: Prepositions {
+                by: vec![
+                    ByName("b".to_string()),
+                    ByName("c".to_string()),
+                ],
+                ..Default::default()
+            },
+            include_done: false,
         }),
     );
 }


### PR DESCRIPTION
Just as you can write 'todo new a --before b' or 'todo new a --after b', you can now write 'todo new a --by b'. Likewise, the 'put' command can use the --by option too.