### PR TITLE
Record PrintableTasks directly in tests.

### DIFF
--- a/app/src/block_test.rs
+++ b/app/src/block_test.rs
@@ -13,8 +13,12 @@ fn block_one_on_one() {
     fix.test("todo block 1 --on 2")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -25,8 +29,12 @@ fn block_by_name() {
     fix.test("todo block a --on b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -37,10 +45,14 @@ fn block_one_on_three() {
     fix.test("todo block 1 --on 2 3 4")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete))
-        .printed_task(&PrintableTask::new("d", 3, Incomplete))
-        .printed_task(&PrintableTask::new("a", 4, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("c", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("d", 3, Incomplete).adeps_stats(0, 1))
+        .printed_task(
+            &PrintableTask::new("a", 4, Blocked)
+                .action(Lock)
+                .deps_stats(3, 3),
+        )
         .end();
 }
 
@@ -51,10 +63,22 @@ fn block_three_on_one() {
     fix.test("todo block 1 2 3 --on 4")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", 1, Incomplete))
-        .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("b", 3, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("c", 4, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("d", 1, Incomplete).adeps_stats(3, 3))
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 3, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -78,9 +102,17 @@ fn block_multiple_on_following_task() {
     fix.test("todo block 1 2 --on 3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("c", 1, Incomplete))
-        .printed_task(&PrintableTask::new("a", 3, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("b", 4, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("c", 1, Incomplete).adeps_stats(2, 2))
+        .printed_task(
+            &PrintableTask::new("a", 3, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -121,15 +153,20 @@ fn block_updates_implicit_priority_of_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("a", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("b", 2, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 3, Blocked)
                 .action(Lock)
-                .priority(Explicit(1)),
+                .priority(Explicit(1))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -143,12 +180,15 @@ fn block_does_not_print_priority_updates_for_unaffected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked).priority(Explicit(1)),
+            &PrintableTask::new("b", 2, Blocked)
+                .priority(Explicit(1))
+                .deps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 3, Blocked)
                 .action(Lock)
-                .priority(Explicit(1)),
+                .priority(Explicit(1))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -163,12 +203,15 @@ fn block_excludes_complete_affected_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("b", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 2, Blocked)
                 .action(Lock)
-                .priority(Explicit(1)),
+                .priority(Explicit(1))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -186,12 +229,15 @@ fn block_include_done() {
             &PrintableTask::new("a", 0, Complete).priority(Implicit(1)),
         )
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("b", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 2, Blocked)
                 .action(Lock)
-                .priority(Explicit(1)),
+                .priority(Explicit(1))
+                .deps_stats(1, 2),
         )
         .end();
 }

--- a/app/src/bottom_test.rs
+++ b/app/src/bottom_test.rs
@@ -31,9 +31,9 @@ fn bottom_all_tasks_categorized_the_same() {
     fix.test("todo bottom")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("b", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("c", 3, Incomplete).adeps_stats(0, 1))
         .end();
 }
 
@@ -46,12 +46,12 @@ fn bottom_multiple_categories() {
     fix.test("todo bottom")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete))
-        .printed_task(&PrintableTask::new("d", 4, Incomplete))
-        .printed_task(&PrintableTask::new("e", 5, Incomplete))
-        .printed_task(&PrintableTask::new("f", 6, Incomplete))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("b", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("c", 3, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("d", 4, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("e", 5, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("f", 6, Incomplete).adeps_stats(0, 1))
         .end();
 }
 
@@ -63,8 +63,8 @@ fn bottom_deep_category() {
     fix.test("todo bottom")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("d", 2, Incomplete))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&PrintableTask::new("d", 2, Incomplete).adeps_stats(1, 2))
         .end();
 }
 
@@ -124,7 +124,7 @@ fn bottom_above_blocking_task() {
     fix.test("todo bottom a")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -135,7 +135,7 @@ fn bottom_above_blocked_task() {
     fix.test("todo bottom b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("c", 3, Blocked))
+        .printed_task(&PrintableTask::new("c", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -149,12 +149,12 @@ fn bottom_above_two_tasks() {
     fix.test("todo bottom x y")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 3, Blocked))
-        .printed_task(&PrintableTask::new("b", 4, Blocked))
-        .printed_task(&PrintableTask::new("c", 5, Blocked))
-        .printed_task(&PrintableTask::new("d", 6, Blocked))
-        .printed_task(&PrintableTask::new("e", 7, Blocked))
-        .printed_task(&PrintableTask::new("f", 8, Blocked))
+        .printed_task(&PrintableTask::new("a", 3, Blocked).deps_stats(1, 1))
+        .printed_task(&PrintableTask::new("b", 4, Blocked).deps_stats(1, 1))
+        .printed_task(&PrintableTask::new("c", 5, Blocked).deps_stats(2, 2))
+        .printed_task(&PrintableTask::new("d", 6, Blocked).deps_stats(2, 2))
+        .printed_task(&PrintableTask::new("e", 7, Blocked).deps_stats(1, 1))
+        .printed_task(&PrintableTask::new("f", 8, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -169,7 +169,7 @@ fn bottom_exclude_adeps_with_indirect_connection() {
         // b should be excluded because there's also an indirect connection to
         // it, through a. On the other hand, a is included because the only
         // path to it from the "bottom" task is direct.
-        .printed_task(&PrintableTask::new("a", 2, Blocked))
+        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 

--- a/app/src/budget_test.rs
+++ b/app/src/budget_test.rs
@@ -64,31 +64,36 @@ fn budget_chain_alters_due_dates() {
             &PrintableTask::new("a", 1, Incomplete)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 19, 59, 59)))
                 .budget(Duration::hours(1))
-                .action(Select),
+                .action(Select)
+                .adeps_stats(1, 4),
         )
         .printed_task(
             &PrintableTask::new("b", 2, Blocked)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 20, 59, 59)))
                 .budget(Duration::hours(1))
-                .action(Select),
+                .action(Select)
+                .deps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 3, Blocked)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 21, 59, 59)))
                 .budget(Duration::hours(1))
-                .action(Select),
+                .action(Select)
+                .deps_stats(1, 2),
         )
         .printed_task(
             &PrintableTask::new("d", 4, Blocked)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 22, 59, 59)))
                 .budget(Duration::hours(1))
-                .action(Select),
+                .action(Select)
+                .deps_stats(1, 3),
         )
         .printed_task(
             &PrintableTask::new("e", 5, Blocked)
                 .due_date(Explicit(ymdhms(2021, 04, 29, 23, 59, 59)))
                 .budget(Duration::hours(1))
-                .action(Select),
+                .action(Select)
+                .deps_stats(1, 4),
         )
         .end();
 }
@@ -103,17 +108,20 @@ fn budget_shows_affected_tasks() {
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
-                .due_date(Implicit(ymdhms(2021, 04, 29, 18, 00, 00))),
+                .due_date(Implicit(ymdhms(2021, 04, 29, 18, 00, 00)))
+                .adeps_stats(1, 2),
         )
         .printed_task(
             &PrintableTask::new("b", 2, Blocked)
-                .due_date(Implicit(ymdhms(2021, 04, 29, 18, 00, 00))),
+                .due_date(Implicit(ymdhms(2021, 04, 29, 18, 00, 00)))
+                .deps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 3, Blocked)
                 .due_date(Explicit(ymdhms(2021, 04, 29, 20, 00, 00)))
                 .budget(Duration::hours(2))
-                .action(Select),
+                .action(Select)
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -129,13 +137,15 @@ fn budget_does_not_show_unaffected_tasks() {
         .validate()
         .printed_task(
             &PrintableTask::new("b", 2, Blocked)
-                .due_date(Implicit(ymdhms(2021, 04, 29, 18, 00, 00))),
+                .due_date(Implicit(ymdhms(2021, 04, 29, 18, 00, 00)))
+                .deps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 3, Blocked)
                 .due_date(Explicit(ymdhms(2021, 04, 29, 20, 00, 00)))
                 .budget(Duration::hours(2))
-                .action(Select),
+                .action(Select)
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -178,13 +188,15 @@ fn budget_does_not_include_complete_affected_deps() {
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete)
-                .due_date(Implicit(ymdhms(2021, 04, 30, 22, 59, 59))),
+                .due_date(Implicit(ymdhms(2021, 04, 30, 22, 59, 59)))
+                .adeps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 2, Blocked)
                 .due_date(Explicit(ymdhms(2021, 04, 30, 23, 59, 59)))
                 .budget(Duration::hours(1))
-                .action(Select),
+                .action(Select)
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -198,19 +210,20 @@ fn budget_include_complete_affected_deps() {
     fix.test("todo budget c --is 1 hour -d")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 0, Complete)
-                .punctuality(-chrono::Duration::hours(10)),
-        )
+        .printed_task(&PrintableTask::new("a", 0, Complete).punctuality(
+            -chrono::Duration::hours(12) + chrono::Duration::seconds(1),
+        ))
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete)
-                .due_date(Implicit(ymdhms(2021, 04, 30, 22, 59, 59))),
+                .due_date(Implicit(ymdhms(2021, 04, 30, 22, 59, 59)))
+                .adeps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 2, Blocked)
                 .due_date(Explicit(ymdhms(2021, 04, 30, 23, 59, 59)))
                 .budget(Duration::hours(1))
-                .action(Select),
+                .action(Select)
+                .deps_stats(1, 2),
         )
         .end();
 }

--- a/app/src/chain_test.rs
+++ b/app/src/chain_test.rs
@@ -20,9 +20,17 @@ fn chain_three() {
     fix.test("todo chain a b c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 4, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("c", 5, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("b", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 5, Blocked)
+                .action(Lock)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -49,15 +57,20 @@ fn chain_shows_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("a", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("b", 2, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 3, Blocked)
                 .priority(Explicit(1))
-                .action(Lock),
+                .action(Lock)
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -72,12 +85,15 @@ fn chain_excludes_complete_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("b", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 2, Blocked)
                 .priority(Explicit(1))
-                .action(Lock),
+                .action(Lock)
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -89,9 +105,17 @@ fn chain_by_range() {
     fix.test("todo chain 1..3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("c", 3, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .action(Lock)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -102,8 +126,16 @@ fn chain_ambiguous_key() {
     fix.test("todo chain a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("a", 3, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("a", 3, Blocked)
+                .action(Lock)
+                .deps_stats(1, 2),
+        )
         .end();
 }

--- a/app/src/check_test.rs
+++ b/app/src/check_test.rs
@@ -105,7 +105,11 @@ fn check_newly_unblocked_task_with_chained_dependencies() {
         .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).action(Unlock))
+        .printed_task(
+            &PrintableTask::new("b", 1, Incomplete)
+                .action(Unlock)
+                .adeps_stats(1, 1),
+        )
         .end();
     fix.test("todo check 1")
         .modified(true)
@@ -129,7 +133,11 @@ fn check_does_not_show_adeps_that_are_not_unlocked() {
         .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).action(Unlock))
+        .printed_task(
+            &PrintableTask::new("b", 1, Incomplete)
+                .action(Unlock)
+                .adeps_stats(1, 1),
+        )
         // Do not print c, even though it's a direct adep, because it has not
         // been unlocked.
         .end();

--- a/app/src/due_test.rs
+++ b/app/src/due_test.rs
@@ -46,13 +46,18 @@ fn show_tasks_with_due_date_includes_blocked() {
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
-                .due_date(Explicit(in_5_hours)),
+                .due_date(Explicit(in_5_hours))
+                .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 5, Blocked).due_date(Implicit(in_2_days)),
+            &PrintableTask::new("b", 5, Blocked)
+                .due_date(Implicit(in_2_days))
+                .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 6, Blocked).due_date(Explicit(in_2_days)),
+            &PrintableTask::new("c", 6, Blocked)
+                .due_date(Explicit(in_2_days))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -72,10 +77,13 @@ fn show_tasks_with_due_date_excludes_complete() {
         .validate()
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete)
-                .due_date(Implicit(in_2_days)),
+                .due_date(Implicit(in_2_days))
+                .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 5, Blocked).due_date(Explicit(in_2_days)),
+            &PrintableTask::new("c", 5, Blocked)
+                .due_date(Explicit(in_2_days))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -95,14 +103,17 @@ fn show_tasks_with_due_date_include_done() {
         .validate()
         .printed_task(
             &PrintableTask::new("a", 0, Complete)
-                .punctuality(chrono::Duration::hours(5)),
+                .punctuality(-chrono::Duration::hours(5)),
         )
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete)
-                .due_date(Implicit(in_2_days)),
+                .due_date(Implicit(in_2_days))
+                .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 5, Blocked).due_date(Explicit(in_2_days)),
+            &PrintableTask::new("c", 5, Blocked)
+                .due_date(Explicit(in_2_days))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -123,7 +134,8 @@ fn show_tasks_with_due_date_earlier_than_given_date() {
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
-                .due_date(Explicit(in_5_hours)),
+                .due_date(Explicit(in_5_hours))
+                .adeps_stats(1, 2),
         )
         .printed_task(
             &PrintableTask::new("g", 2, Incomplete)
@@ -148,11 +160,12 @@ fn show_tasks_with_due_date_earlier_than_given_date_include_done() {
         .validate()
         .printed_task(
             &PrintableTask::new("g", 0, Complete)
-                .punctuality(chrono::Duration::hours(6)),
+                .punctuality(-chrono::Duration::hours(6)),
         )
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
-                .due_date(Explicit(in_5_hours)),
+                .due_date(Explicit(in_5_hours))
+                .adeps_stats(1, 2),
         )
         .end();
 }
@@ -171,13 +184,18 @@ fn show_source_of_implicit_due_date() {
         .validate()
         .printed_task(
             &PrintableTask::new("a", 4, Incomplete)
-                .due_date(Implicit(in_2_days)),
+                .due_date(Implicit(in_2_days))
+                .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 5, Blocked).due_date(Implicit(in_2_days)),
+            &PrintableTask::new("b", 5, Blocked)
+                .due_date(Implicit(in_2_days))
+                .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 6, Blocked).due_date(Explicit(in_2_days)),
+            &PrintableTask::new("c", 6, Blocked)
+                .due_date(Explicit(in_2_days))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -228,14 +246,14 @@ fn set_due_date_include_done() {
     // Monday.
     fix.clock.now = ymdhms(2021, 04, 12, 14, 00, 00);
     let thursday = ymdhms(2021, 04, 15, 23, 59, 59);
+    let punctuality = fix.clock.now - thursday;
     fix.test("todo new a b --chain");
     fix.test("todo check a");
     fix.test("todo due b --on thursday --include-done")
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 0, Complete)
-                .punctuality(fix.clock.now - thursday),
+            &PrintableTask::new("a", 0, Complete).punctuality(punctuality),
         )
         .printed_task(
             &PrintableTask::new("b", 1, Incomplete)
@@ -258,13 +276,18 @@ fn set_due_date_prints_affected_tasks() {
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
-                .due_date(Implicit(in_1_hour)),
+                .due_date(Implicit(in_1_hour))
+                .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 5, Blocked).due_date(Implicit(in_1_hour)),
+            &PrintableTask::new("b", 5, Blocked)
+                .due_date(Implicit(in_1_hour))
+                .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 6, Blocked).due_date(Explicit(in_1_hour)),
+            &PrintableTask::new("c", 6, Blocked)
+                .due_date(Explicit(in_1_hour))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -279,8 +302,8 @@ fn reset_due_date() {
     fix.test("todo due c --none")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 5, Blocked))
-        .printed_task(&PrintableTask::new("c", 6, Blocked))
+        .printed_task(&PrintableTask::new("b", 5, Blocked).deps_stats(1, 1))
+        .printed_task(&PrintableTask::new("c", 6, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -293,9 +316,9 @@ fn show_tasks_without_due_dates() {
     fix.test("todo due --none")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("g", 4, Incomplete))
-        .printed_task(&PrintableTask::new("h", 8, Blocked))
-        .printed_task(&PrintableTask::new("i", 9, Blocked))
+        .printed_task(&PrintableTask::new("g", 4, Incomplete).adeps_stats(1, 2))
+        .printed_task(&PrintableTask::new("h", 8, Blocked).deps_stats(1, 1))
+        .printed_task(&PrintableTask::new("i", 9, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -308,8 +331,8 @@ fn show_tasks_without_due_date_excludes_complete() {
     fix.test("todo due --none")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("e", 4, Incomplete))
-        .printed_task(&PrintableTask::new("f", 5, Blocked))
+        .printed_task(&PrintableTask::new("e", 4, Incomplete).adeps_stats(1, 1))
+        .printed_task(&PrintableTask::new("f", 5, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -323,8 +346,8 @@ fn show_tasks_without_due_date_include_done() {
         .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("d", 0, Complete))
-        .printed_task(&PrintableTask::new("e", 4, Incomplete))
-        .printed_task(&PrintableTask::new("f", 5, Blocked))
+        .printed_task(&PrintableTask::new("e", 4, Incomplete).adeps_stats(1, 1))
+        .printed_task(&PrintableTask::new("f", 5, Blocked).deps_stats(1, 2))
         .end();
 }
 

--- a/app/src/find_test.rs
+++ b/app/src/find_test.rs
@@ -65,7 +65,11 @@ fn find_includes_blocked_tasks() {
     fix.test("todo find b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("aba", 2, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("aba", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -90,11 +94,26 @@ fn find_includes_matches_with_tag() {
     fix.test("todo find g")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 4, Incomplete).tag("g"))
-        .printed_task(&PrintableTask::new("b", 5, Incomplete).tag("g"))
-        .printed_task(&PrintableTask::new("c", 6, Incomplete).tag("g"))
         .printed_task(
-            &PrintableTask::new("g", 7, Blocked).as_tag().action(Select),
+            &PrintableTask::new("a", 4, Incomplete)
+                .tag("g")
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 5, Incomplete)
+                .tag("g")
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 6, Incomplete)
+                .tag("g")
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("g", 7, Blocked)
+                .as_tag()
+                .action(Select)
+                .deps_stats(3, 3),
         )
         .end();
 }
@@ -146,13 +165,26 @@ fn find_incomplete_matches_with_tag() {
     fix.test("todo find gg")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 4, Incomplete).tag("ggg"))
-        .printed_task(&PrintableTask::new("b", 5, Incomplete).tag("ggg"))
-        .printed_task(&PrintableTask::new("c", 6, Incomplete).tag("ggg"))
+        .printed_task(
+            &PrintableTask::new("a", 4, Incomplete)
+                .tag("ggg")
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 5, Incomplete)
+                .tag("ggg")
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 6, Incomplete)
+                .tag("ggg")
+                .adeps_stats(0, 1),
+        )
         .printed_task(
             &PrintableTask::new("ggg", 7, Blocked)
                 .as_tag()
-                .action(Select),
+                .action(Select)
+                .deps_stats(3, 3),
         )
         .end();
 }

--- a/app/src/get_test.rs
+++ b/app/src/get_test.rs
@@ -72,8 +72,12 @@ fn get_shows_blocking_tasks() {
     fix.test("todo get 2")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -85,8 +89,12 @@ fn get_shows_blocked_tasks() {
     fix.test("todo get 1")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -97,11 +105,15 @@ fn get_shows_transitive_deps_and_adeps() {
     fix.test("todo get 3")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("c", 3, Blocked).action(Select))
-        .printed_task(&PrintableTask::new("d", 4, Blocked))
-        .printed_task(&PrintableTask::new("e", 5, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 4))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .action(Select)
+                .deps_stats(1, 2),
+        )
+        .printed_task(&PrintableTask::new("d", 4, Blocked).deps_stats(1, 3))
+        .printed_task(&PrintableTask::new("e", 5, Blocked).deps_stats(1, 4))
         .end();
 }
 
@@ -124,7 +136,11 @@ fn get_no_context_single_task_by_name() {
     fix.test("todo get a -n")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .adeps_stats(1, 2),
+        )
         .end();
 }
 
@@ -135,8 +151,16 @@ fn get_no_context_multiple_tasks_by_name() {
     fix.test("todo get a b -n")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .adeps_stats(1, 2),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -172,7 +196,11 @@ fn get_no_context_blocked_task() {
     fix.test("todo get c -n")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("c", 3, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .action(Select)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -185,7 +213,11 @@ fn get_no_context_complete_and_incomplete_match() {
         .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).action(Select))
-        .printed_task(&PrintableTask::new("a", 2, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -196,8 +228,12 @@ fn get_blocked_by_one_task() {
     fix.test("todo get --blocked-by b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
-        .printed_task(&PrintableTask::new("c", 3, Blocked))
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("c", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -208,10 +244,14 @@ fn get_blocked_by_shows_transitive_adeps() {
     fix.test("todo get --blocked-by b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
-        .printed_task(&PrintableTask::new("c", 3, Blocked))
-        .printed_task(&PrintableTask::new("d", 4, Blocked))
-        .printed_task(&PrintableTask::new("e", 5, Blocked))
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("c", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&PrintableTask::new("d", 4, Blocked).deps_stats(1, 3))
+        .printed_task(&PrintableTask::new("e", 5, Blocked).deps_stats(1, 4))
         .end();
 }
 
@@ -222,8 +262,12 @@ fn get_blocking_one_task() {
     fix.test("todo get --blocking b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -234,9 +278,13 @@ fn get_blocking_shows_transitive_deps() {
     fix.test("todo get --blocking d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("c", 3, Blocked))
-        .printed_task(&PrintableTask::new("d", 4, Blocked).action(Select))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 4))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&PrintableTask::new("c", 3, Blocked).deps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("d", 4, Blocked)
+                .action(Select)
+                .deps_stats(1, 3),
+        )
         .end();
 }

--- a/app/src/merge_test.rs
+++ b/app/src/merge_test.rs
@@ -38,8 +38,12 @@ fn merge_preserves_deps() {
     fix.test("todo merge b c --into bc")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("bc", 2, Blocked).action(Select))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("bc", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -50,8 +54,12 @@ fn merge_preserves_adeps() {
     fix.test("todo merge a b --into ab")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("ab", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("c", 2, Blocked))
+        .printed_task(
+            &PrintableTask::new("ab", 1, Incomplete)
+                .action(Select)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("c", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -62,9 +70,13 @@ fn merge_preserves_deps_and_adeps() {
     fix.test("todo merge b c d --into bcd")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("bcd", 2, Blocked).action(Select))
-        .printed_task(&PrintableTask::new("e", 3, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("bcd", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("e", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -146,9 +158,13 @@ fn merge_inside_chain() {
     fix.test("todo merge c d --into cd")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("cd", 3, Blocked).action(Select))
-        .printed_task(&PrintableTask::new("e", 4, Blocked))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("cd", 3, Blocked)
+                .action(Select)
+                .deps_stats(1, 2),
+        )
+        .printed_task(&PrintableTask::new("e", 4, Blocked).deps_stats(1, 3))
         .end();
 }
 
@@ -256,9 +272,14 @@ fn show_tags_for_merged_task() {
             &PrintableTask::new("ab", 1, Incomplete)
                 .action(Select)
                 .as_tag()
-                .tag("c"),
+                .tag("c")
+                .adeps_stats(1, 1),
         )
-        .printed_task(&PrintableTask::new("c", 2, Blocked).as_tag())
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .as_tag()
+                .deps_stats(1, 1),
+        )
         .end();
 }
 

--- a/app/src/new_test.rs
+++ b/app/src/new_test.rs
@@ -53,8 +53,12 @@ fn new_blocking_complete_task() {
     fix.test("todo new b -b 0")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a", 2, Blocked))
+        .printed_task(
+            &PrintableTask::new("b", 1, Incomplete)
+                .action(New)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -65,9 +69,13 @@ fn new_by_name() {
     fix.test("todo new d -p c -b a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("c", 2, Incomplete))
-        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
-        .printed_task(&PrintableTask::new("a", 4, Blocked))
+        .printed_task(&PrintableTask::new("c", 2, Incomplete).adeps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("d", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("a", 4, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -77,9 +85,21 @@ fn new_chain_three() {
     fix.test("todo new a b c --chain")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c", 3, Blocked).action(New))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(New)
+                .adeps_stats(1, 2),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -90,8 +110,12 @@ fn new_one_blocking_one() {
     fix.test("todo new b --blocking 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a", 2, Blocked))
+        .printed_task(
+            &PrintableTask::new("b", 1, Incomplete)
+                .action(New)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -102,8 +126,12 @@ fn new_blocked_by_one() {
     fix.test("todo new b --blocked-by 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(New))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -114,8 +142,12 @@ fn new_one_blocking_one_short() {
     fix.test("todo new b -b 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a", 2, Blocked))
+        .printed_task(
+            &PrintableTask::new("b", 1, Incomplete)
+                .action(New)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -126,8 +158,12 @@ fn new_blocked_by_one_short() {
     fix.test("todo new b -p 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(New))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -138,10 +174,14 @@ fn new_blocking_multiple() {
     fix.test("todo new d -b 1 2 3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a", 2, Blocked))
-        .printed_task(&PrintableTask::new("b", 3, Blocked))
-        .printed_task(&PrintableTask::new("c", 4, Blocked))
+        .printed_task(
+            &PrintableTask::new("d", 1, Incomplete)
+                .action(New)
+                .adeps_stats(3, 3),
+        )
+        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 1))
+        .printed_task(&PrintableTask::new("c", 4, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -152,9 +192,13 @@ fn new_blocking_and_blocked_by() {
     fix.test("todo new c -p 1 -b 2")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).action(New))
-        .printed_task(&PrintableTask::new("b", 3, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -165,9 +209,13 @@ fn new_in_between_blocking_pair() {
     fix.test("todo new c -p 1 -b 2")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).action(New))
-        .printed_task(&PrintableTask::new("b", 3, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -178,9 +226,13 @@ fn new_one_before_one() {
     fix.test("todo new d --before b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("d", 2, Blocked).action(New))
-        .printed_task(&PrintableTask::new("b", 3, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 3))
+        .printed_task(
+            &PrintableTask::new("d", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -191,11 +243,23 @@ fn new_three_before_one() {
     fix.test("todo new d e f --before b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("d", 2, Blocked).action(New))
-        .printed_task(&PrintableTask::new("e", 3, Blocked).action(New))
-        .printed_task(&PrintableTask::new("f", 4, Blocked).action(New))
-        .printed_task(&PrintableTask::new("b", 5, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(3, 5))
+        .printed_task(
+            &PrintableTask::new("d", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("e", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("f", 4, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("b", 5, Blocked).deps_stats(1, 4))
         .end();
 }
 
@@ -207,11 +271,15 @@ fn new_one_before_three() {
     fix.test("todo new e --before b c d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("e", 2, Blocked).action(New))
-        .printed_task(&PrintableTask::new("b", 3, Blocked))
-        .printed_task(&PrintableTask::new("c", 4, Blocked))
-        .printed_task(&PrintableTask::new("d", 5, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 4))
+        .printed_task(
+            &PrintableTask::new("e", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&PrintableTask::new("c", 4, Blocked).deps_stats(1, 2))
+        .printed_task(&PrintableTask::new("d", 5, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -222,9 +290,13 @@ fn new_one_after_one() {
     fix.test("todo new d --after b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c", 4, Blocked))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("d", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 2),
+        )
+        .printed_task(&PrintableTask::new("c", 4, Blocked).deps_stats(1, 3))
         .end();
 }
 
@@ -235,11 +307,23 @@ fn new_three_after_one() {
     fix.test("todo new d e f --after b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
-        .printed_task(&PrintableTask::new("e", 4, Blocked).action(New))
-        .printed_task(&PrintableTask::new("f", 5, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c", 6, Blocked))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("d", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 2),
+        )
+        .printed_task(
+            &PrintableTask::new("e", 4, Blocked)
+                .action(New)
+                .deps_stats(1, 2),
+        )
+        .printed_task(
+            &PrintableTask::new("f", 5, Blocked)
+                .action(New)
+                .deps_stats(1, 2),
+        )
+        .printed_task(&PrintableTask::new("c", 6, Blocked).deps_stats(1, 5))
         .end();
 }
 
@@ -250,11 +334,15 @@ fn new_one_after_three() {
     fix.test("todo new d -p a b c");
     fix.test("todo new e --after a b c")
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete))
-        .printed_task(&PrintableTask::new("e", 4, Blocked).action(New))
-        .printed_task(&PrintableTask::new("d", 5, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 2))
+        .printed_task(&PrintableTask::new("b", 2, Incomplete).adeps_stats(0, 2))
+        .printed_task(&PrintableTask::new("c", 3, Incomplete).adeps_stats(0, 2))
+        .printed_task(
+            &PrintableTask::new("e", 4, Blocked)
+                .action(New)
+                .deps_stats(3, 3),
+        )
+        .printed_task(&PrintableTask::new("d", 5, Blocked).deps_stats(3, 4))
         .end();
 }
 
@@ -265,9 +353,13 @@ fn new_one_by_one() {
     fix.test("todo new d --by b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c", 4, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 3))
+        .printed_task(
+            &PrintableTask::new("d", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("c", 4, Blocked).deps_stats(1, 3))
         .end();
 }
 
@@ -278,11 +370,23 @@ fn new_three_by_one() {
     fix.test("todo new d e f --by b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
-        .printed_task(&PrintableTask::new("e", 4, Blocked).action(New))
-        .printed_task(&PrintableTask::new("f", 5, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c", 6, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(4, 5))
+        .printed_task(
+            &PrintableTask::new("d", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("e", 4, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("f", 5, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("c", 6, Blocked).deps_stats(1, 5))
         .end();
 }
 
@@ -294,8 +398,12 @@ fn new_one_by_three() {
     fix.test("todo new e --by a b c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("e", 4, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("d", 5, Blocked))
+        .printed_task(
+            &PrintableTask::new("e", 4, Incomplete)
+                .action(New)
+                .adeps_stats(0, 1),
+        )
+        .printed_task(&PrintableTask::new("d", 5, Blocked).deps_stats(4, 4))
         .end();
 }
 
@@ -306,9 +414,13 @@ fn new_one_by_one_with_chain() {
     fix.test("todo new d --by b --chain")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c", 4, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 3))
+        .printed_task(
+            &PrintableTask::new("d", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("c", 4, Blocked).deps_stats(1, 3))
         .end();
 }
 
@@ -319,11 +431,23 @@ fn new_three_by_one_with_chain() {
     fix.test("todo new d e f --by b --chain")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("d", 3, Blocked).action(New))
-        .printed_task(&PrintableTask::new("e", 4, Blocked).action(New))
-        .printed_task(&PrintableTask::new("f", 5, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c", 6, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 5))
+        .printed_task(
+            &PrintableTask::new("d", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("e", 4, Blocked)
+                .action(New)
+                .deps_stats(1, 2),
+        )
+        .printed_task(
+            &PrintableTask::new("f", 5, Blocked)
+                .action(New)
+                .deps_stats(1, 3),
+        )
+        .printed_task(&PrintableTask::new("c", 6, Blocked).deps_stats(1, 5))
         .end();
 }
 
@@ -441,18 +565,24 @@ fn new_with_due_date_shows_affected_deps() {
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
-                .due_date(Implicit(in_2_days)),
+                .due_date(Implicit(in_2_days))
+                .adeps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked).due_date(Implicit(in_2_days)),
+            &PrintableTask::new("b", 2, Blocked)
+                .due_date(Implicit(in_2_days))
+                .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked).due_date(Implicit(in_2_days)),
+            &PrintableTask::new("c", 3, Blocked)
+                .due_date(Implicit(in_2_days))
+                .deps_stats(1, 2),
         )
         .printed_task(
             &PrintableTask::new("d", 4, Blocked)
                 .due_date(Explicit(in_2_days))
-                .action(New),
+                .action(New)
+                .deps_stats(1, 3),
         )
         .end();
 }
@@ -469,13 +599,15 @@ fn new_with_budget_shows_affected_deps() {
         .validate()
         .printed_task(
             &PrintableTask::new("a", 1, Incomplete)
-                .due_date(Implicit(before_7)),
+                .due_date(Implicit(before_7))
+                .adeps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("b", 2, Blocked)
                 .due_date(Explicit(end_of_day))
                 .budget(Duration::hours(5))
-                .action(New),
+                .action(New)
+                .deps_stats(1, 1),
         )
         .end();
 }
@@ -645,8 +777,12 @@ fn new_block_completed_task() {
     fix.test("todo new b -b a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a", 2, Blocked))
+        .printed_task(
+            &PrintableTask::new("b", 1, Incomplete)
+                .action(New)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -657,9 +793,13 @@ fn new_transitively_block_completed_task() {
     fix.test("todo new a -b b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("c", 3, Blocked))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(New)
+                .adeps_stats(1, 2),
+        )
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&PrintableTask::new("c", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -701,9 +841,16 @@ fn new_blocking_tag() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete).action(New).tag("a"),
+            &PrintableTask::new("b", 1, Incomplete)
+                .action(New)
+                .tag("a")
+                .adeps_stats(1, 1),
         )
-        .printed_task(&PrintableTask::new("a", 2, Blocked).as_tag())
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .as_tag()
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -718,9 +865,14 @@ fn new_tag_blocking_tag() {
             &PrintableTask::new("b", 1, Incomplete)
                 .action(New)
                 .tag("a")
-                .as_tag(),
+                .as_tag()
+                .adeps_stats(1, 1),
         )
-        .printed_task(&PrintableTask::new("a", 2, Blocked).as_tag())
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .as_tag()
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -735,15 +887,22 @@ fn new_tag_chain() {
                 .action(New)
                 .tag("c")
                 .tag("b")
-                .as_tag(),
+                .as_tag()
+                .adeps_stats(1, 2),
         )
         .printed_task(
             &PrintableTask::new("b", 2, Blocked)
                 .action(New)
                 .tag("c")
-                .as_tag(),
+                .as_tag()
+                .deps_stats(1, 1),
         )
-        .printed_task(&PrintableTask::new("c", 3, Blocked).action(New).as_tag())
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .action(New)
+                .as_tag()
+                .deps_stats(1, 2),
+        )
         .end();
 }
 

--- a/app/src/path_test.rs
+++ b/app/src/path_test.rs
@@ -28,8 +28,16 @@ fn path_between_tasks_with_direct_dependency() {
     fix.test("todo path a b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -40,9 +48,17 @@ fn path_between_tasks_with_indirect_dependency() {
     fix.test("todo path a c")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("c", 3, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .adeps_stats(1, 2),
+        )
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .action(Select)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -114,9 +130,17 @@ fn path_between_tasks_of_same_name() {
                 BriefPrintableTask::new(3, Blocked),
             ],
         })
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("a", 3, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .adeps_stats(1, 2),
+        )
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("a", 3, Blocked)
+                .action(Select)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -127,10 +151,22 @@ fn path_between_three_tasks() {
     fix.test("todo path a c e")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("c", 3, Blocked).action(Select))
-        .printed_task(&PrintableTask::new("d", 4, Blocked))
-        .printed_task(&PrintableTask::new("e", 5, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Select)
+                .adeps_stats(1, 4),
+        )
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .action(Select)
+                .deps_stats(1, 2),
+        )
+        .printed_task(&PrintableTask::new("d", 4, Blocked).deps_stats(1, 3))
+        .printed_task(
+            &PrintableTask::new("e", 5, Blocked)
+                .action(Select)
+                .deps_stats(1, 4),
+        )
         .end();
 }

--- a/app/src/priority_test.rs
+++ b/app/src/priority_test.rs
@@ -66,13 +66,19 @@ fn priority_shows_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("a", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 2, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("c", 2, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("d", 4, Blocked).priority(Explicit(1)),
+            &PrintableTask::new("d", 4, Blocked)
+                .priority(Explicit(1))
+                .deps_stats(2, 2),
         )
         .end();
 }
@@ -87,10 +93,14 @@ fn priority_does_not_show_complete_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("c", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("c", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("d", 3, Blocked).priority(Explicit(1)),
+            &PrintableTask::new("d", 3, Blocked)
+                .priority(Explicit(1))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -108,10 +118,14 @@ fn priority_include_done() {
             &PrintableTask::new("a", 0, Complete).priority(Implicit(1)),
         )
         .printed_task(
-            &PrintableTask::new("c", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("c", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("d", 3, Blocked).priority(Explicit(1)),
+            &PrintableTask::new("d", 3, Blocked)
+                .priority(Explicit(1))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -124,13 +138,19 @@ fn priority_shows_affected_transitive_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("a", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("b", 2, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked).priority(Explicit(1)),
+            &PrintableTask::new("c", 3, Blocked)
+                .priority(Explicit(1))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -158,16 +178,24 @@ fn priority_does_not_show_deps_with_higher_priorities() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("d", 4, Incomplete).priority(Implicit(2)),
+            &PrintableTask::new("d", 4, Incomplete)
+                .priority(Implicit(2))
+                .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("e", 5, Incomplete).priority(Implicit(2)),
+            &PrintableTask::new("e", 5, Incomplete)
+                .priority(Implicit(2))
+                .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("f", 6, Incomplete).priority(Implicit(2)),
+            &PrintableTask::new("f", 6, Incomplete)
+                .priority(Implicit(2))
+                .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("g", 7, Blocked).priority(Explicit(2)),
+            &PrintableTask::new("g", 7, Blocked)
+                .priority(Explicit(2))
+                .deps_stats(6, 6),
         )
         .end();
 }
@@ -232,13 +260,19 @@ fn explain_source_of_priority() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("a", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("b", 2, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked).priority(Explicit(1)),
+            &PrintableTask::new("c", 3, Blocked)
+                .priority(Explicit(1))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -252,25 +286,39 @@ fn explain_source_of_priority_deep() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("a", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 8),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("b", 2, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("c", 3, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("d", 4, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("d", 4, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("e", 5, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("e", 5, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 4),
         )
         .printed_task(
-            &PrintableTask::new("f", 6, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("f", 6, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 5),
         )
         .printed_task(
-            &PrintableTask::new("g", 7, Blocked).priority(Explicit(1)),
+            &PrintableTask::new("g", 7, Blocked)
+                .priority(Explicit(1))
+                .deps_stats(1, 6),
         )
         .end();
 }

--- a/app/src/punt_test.rs
+++ b/app/src/punt_test.rs
@@ -24,7 +24,11 @@ fn punt_blocked_task() {
         // need to mark the session as modified.
         // .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 3, Blocked).action(Punt))
+        .printed_task(
+            &PrintableTask::new("b", 3, Blocked)
+                .action(Punt)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 

--- a/app/src/put_test.rs
+++ b/app/src/put_test.rs
@@ -13,8 +13,12 @@ fn put_one_after_one() {
     fix.test("todo put a --after b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -25,10 +29,22 @@ fn put_three_after_one() {
     fix.test("todo put a b c --after d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", 1, Incomplete))
-        .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("b", 3, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("c", 4, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("d", 1, Incomplete).adeps_stats(3, 3))
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 3, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -39,10 +55,14 @@ fn put_one_after_three() {
     fix.test("todo put a --after b c d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete))
-        .printed_task(&PrintableTask::new("d", 3, Incomplete))
-        .printed_task(&PrintableTask::new("a", 4, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("c", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("d", 3, Incomplete).adeps_stats(0, 1))
+        .printed_task(
+            &PrintableTask::new("a", 4, Blocked)
+                .action(Lock)
+                .deps_stats(3, 3),
+        )
         .end();
 }
 
@@ -54,9 +74,17 @@ fn put_after_task_with_adeps() {
     fix.test("todo put c --after a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("b", 3, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 3, Blocked)
+                .action(Lock)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -67,8 +95,12 @@ fn put_one_before_one() {
     fix.test("todo put b --before a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -79,10 +111,14 @@ fn put_three_before_one() {
     fix.test("todo put b c d --before a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete))
-        .printed_task(&PrintableTask::new("d", 3, Incomplete))
-        .printed_task(&PrintableTask::new("a", 4, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("c", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("d", 3, Incomplete).adeps_stats(0, 1))
+        .printed_task(
+            &PrintableTask::new("a", 4, Blocked)
+                .action(Lock)
+                .deps_stats(3, 3),
+        )
         .end();
 }
 
@@ -93,10 +129,22 @@ fn put_one_before_three() {
     fix.test("todo put d --before a b c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", 1, Incomplete))
-        .printed_task(&PrintableTask::new("a", 2, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("b", 3, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("c", 4, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("d", 1, Incomplete).adeps_stats(3, 3))
+        .printed_task(
+            &PrintableTask::new("a", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 3, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -108,9 +156,17 @@ fn put_before_task_with_deps() {
     fix.test("todo put c --before b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("b", 3, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 3, Blocked)
+                .action(Lock)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -123,11 +179,23 @@ fn put_before_and_after() {
     fix.test("todo put g -B b -A e")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("e", 3, Blocked))
-        .printed_task(&PrintableTask::new("g", 4, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("b", 5, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("f", 6, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 4))
+        .printed_task(&PrintableTask::new("e", 3, Blocked).deps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("g", 4, Blocked)
+                .action(Lock)
+                .deps_stats(2, 3),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 5, Blocked)
+                .action(Lock)
+                .deps_stats(2, 4),
+        )
+        .printed_task(
+            &PrintableTask::new("f", 6, Blocked)
+                .action(Lock)
+                .deps_stats(2, 4),
+        )
         .end();
 }
 
@@ -146,8 +214,8 @@ fn put_causing_cycle() {
     fix.test("todo -a")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -160,17 +228,26 @@ fn put_before_prints_updated_priority() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("a", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("b", 2, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 3, Blocked)
                 .priority(Explicit(1))
-                .action(Lock),
+                .action(Lock)
+                .deps_stats(1, 2),
         )
-        .printed_task(&PrintableTask::new("d", 4, Blocked).action(Lock))
+        .printed_task(
+            &PrintableTask::new("d", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 3),
+        )
         .end();
 }
 
@@ -183,17 +260,26 @@ fn put_after_prints_updated_priority() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("a", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked).priority(Implicit(1)),
+            &PrintableTask::new("b", 2, Blocked)
+                .priority(Implicit(1))
+                .deps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 3, Blocked)
                 .priority(Explicit(1))
-                .action(Lock),
+                .action(Lock)
+                .deps_stats(1, 2),
         )
-        .printed_task(&PrintableTask::new("d", 4, Blocked).action(Lock))
+        .printed_task(
+            &PrintableTask::new("d", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 3),
+        )
         .end();
 }
 
@@ -207,12 +293,15 @@ fn put_excludes_complete_affected_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("b", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 2, Blocked)
                 .priority(Explicit(1))
-                .action(Lock),
+                .action(Lock)
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -230,12 +319,15 @@ fn put_include_done() {
             &PrintableTask::new("a", 0, Complete).priority(Implicit(1)),
         )
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete).priority(Implicit(1)),
+            &PrintableTask::new("b", 1, Incomplete)
+                .priority(Implicit(1))
+                .adeps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("c", 2, Blocked)
                 .priority(Explicit(1))
-                .action(Lock),
+                .action(Lock)
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -248,8 +340,12 @@ fn put_task_by_initial_task() {
     fix.test("todo put t --by a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("t", 2, Incomplete))
-        .printed_task(&PrintableTask::new("b", 3, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("t", 2, Incomplete).adeps_stats(0, 2))
+        .printed_task(
+            &PrintableTask::new("b", 3, Blocked)
+                .action(Lock)
+                .deps_stats(2, 2),
+        )
         .end();
 }
 
@@ -261,9 +357,17 @@ fn put_task_by_interior_task() {
     fix.test("todo put t --by b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("t", 3, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("c", 4, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 3))
+        .printed_task(
+            &PrintableTask::new("t", 3, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 3),
+        )
         .end();
 }
 
@@ -275,8 +379,12 @@ fn put_task_by_terminal_task() {
     fix.test("todo put t --by c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
-        .printed_task(&PrintableTask::new("t", 4, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("t", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -300,8 +408,16 @@ fn put_task_by_complete_task() {
     fix.test("todo put t --by b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("t", 1, Incomplete).action(Lock))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).action(Lock))
+        .printed_task(
+            &PrintableTask::new("t", 1, Incomplete)
+                .action(Lock)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 3),
+        )
         .end();
 }
 
@@ -315,8 +431,16 @@ fn put_task_by_complete_task_include_done() {
         .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -1, Complete))
-        .printed_task(&PrintableTask::new("t", 1, Incomplete).action(Lock))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).action(Lock))
+        .printed_task(
+            &PrintableTask::new("t", 1, Incomplete)
+                .action(Lock)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 3),
+        )
         .end();
 }
 
@@ -330,8 +454,16 @@ fn put_task_by_task_whose_adeps_are_complete() {
         .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", -1, Complete))
-        .printed_task(&PrintableTask::new("t", 1, Incomplete).action(Lock))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).action(Lock))
+        .printed_task(
+            &PrintableTask::new("t", 1, Incomplete)
+                .action(Lock)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 3),
+        )
         .end();
 }
 
@@ -343,8 +475,16 @@ fn put_complete_task_by_task() {
     fix.test("todo put t --by b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("t", 3, Blocked).action(Lock))
-        .printed_task(&PrintableTask::new("c", 4, Blocked).action(Lock))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 3))
+        .printed_task(
+            &PrintableTask::new("t", 3, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 3),
+        )
         .end();
 }

--- a/app/src/restore_test.rs
+++ b/app/src/restore_test.rs
@@ -67,8 +67,16 @@ fn restore_task_with_incomplete_antidependency() {
     fix.test("todo restore 0")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Lock))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Uncheck)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Lock)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -140,8 +148,16 @@ fn force_restore_task_with_complete_adeps() {
     fix.test("todo restore a --force")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Uncheck))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Uncheck)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Uncheck)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -153,9 +169,21 @@ fn force_restore_task_with_complete_adeps_with_complete_adeps() {
     fix.test("todo restore a --force")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Uncheck))
-        .printed_task(&PrintableTask::new("c", 3, Blocked).action(Uncheck))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Uncheck)
+                .adeps_stats(1, 2),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Uncheck)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .action(Uncheck)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -167,10 +195,26 @@ fn force_restore_task_with_complete_and_incomplete_adeps() {
     fix.test("todo restore a --force")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Uncheck))
-        .printed_task(&PrintableTask::new("c", 3, Blocked).action(Uncheck))
-        .printed_task(&PrintableTask::new("d", 4, Blocked).action(Lock))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Uncheck)
+                .adeps_stats(1, 3),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Uncheck)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .action(Uncheck)
+                .deps_stats(1, 2),
+        )
+        .printed_task(
+            &PrintableTask::new("d", 4, Blocked)
+                .action(Lock)
+                .deps_stats(1, 3),
+        )
         .end();
 }
 
@@ -182,7 +226,15 @@ fn restore_chain() {
     fix.test("todo restore a b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).action(Uncheck))
+        .printed_task(
+            &PrintableTask::new("a", 1, Incomplete)
+                .action(Uncheck)
+                .adeps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .action(Uncheck)
+                .deps_stats(1, 1),
+        )
         .end();
 }

--- a/app/src/rm_test.rs
+++ b/app/src/rm_test.rs
@@ -46,7 +46,7 @@ fn rm_task_with_deps_and_adeps() {
         .modified(true)
         .validate()
         .printed_info(&info_removed("b"))
-        .printed_task(&PrintableTask::new("c", 2, Blocked))
+        .printed_task(&PrintableTask::new("c", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 

--- a/app/src/snooze_test.rs
+++ b/app/src/snooze_test.rs
@@ -106,7 +106,8 @@ fn snooze_blocked_task_above_layer_1() {
         .printed_task(
             &PrintableTask::new("c", 3, Blocked)
                 .start_date(ymdhms(2021, 05, 28, 00, 00, 00))
-                .action(Snooze),
+                .action(Snooze)
+                .deps_stats(1, 2),
         )
         .end();
 }

--- a/app/src/split_test.rs
+++ b/app/src/split_test.rs
@@ -28,9 +28,21 @@ fn split_chained() {
     fix.test("todo split a --into a1 a2 a3 --chain")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a1", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a2", 2, Blocked).action(New))
-        .printed_task(&PrintableTask::new("a3", 3, Blocked).action(New))
+        .printed_task(
+            &PrintableTask::new("a1", 1, Incomplete)
+                .action(New)
+                .adeps_stats(1, 2),
+        )
+        .printed_task(
+            &PrintableTask::new("a2", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("a3", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -41,11 +53,23 @@ fn split_preserves_dependency_structure() {
     fix.test("todo split b --into b1 b2 b3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b1", 2, Blocked).action(New))
-        .printed_task(&PrintableTask::new("b2", 3, Blocked).action(New))
-        .printed_task(&PrintableTask::new("b3", 4, Blocked).action(New))
-        .printed_task(&PrintableTask::new("c", 5, Blocked))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(3, 4))
+        .printed_task(
+            &PrintableTask::new("b1", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b2", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("b3", 4, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(&PrintableTask::new("c", 5, Blocked).deps_stats(1, 4))
         .end();
 }
 
@@ -80,17 +104,20 @@ fn chained_split_task_with_budget_distributes_budget() {
         .printed_task(
             &PrintableTask::new("x", 1, Incomplete)
                 .action(New)
-                .budget(Duration::hours(1)),
+                .budget(Duration::hours(1))
+                .adeps_stats(1, 2),
         )
         .printed_task(
             &PrintableTask::new("y", 2, Blocked)
                 .action(New)
-                .budget(Duration::hours(1)),
+                .budget(Duration::hours(1))
+                .deps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("z", 3, Blocked)
                 .action(New)
-                .budget(Duration::hours(1)),
+                .budget(Duration::hours(1))
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -127,10 +154,26 @@ fn split_task_keep() {
     fix.test("todo split a --into x y z --keep")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("x", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("y", 2, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("z", 3, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a", 4, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("x", 1, Incomplete)
+                .action(New)
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("y", 2, Incomplete)
+                .action(New)
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("z", 3, Incomplete)
+                .action(New)
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("a", 4, Blocked)
+                .action(Select)
+                .deps_stats(3, 3),
+        )
         .end();
 }
 
@@ -141,10 +184,26 @@ fn split_task_keep_chained() {
     fix.test("todo split a --into x y z --keep --chain")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("x", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("y", 2, Blocked).action(New))
-        .printed_task(&PrintableTask::new("z", 3, Blocked).action(New))
-        .printed_task(&PrintableTask::new("a", 4, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("x", 1, Incomplete)
+                .action(New)
+                .adeps_stats(1, 3),
+        )
+        .printed_task(
+            &PrintableTask::new("y", 2, Blocked)
+                .action(New)
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("z", 3, Blocked)
+                .action(New)
+                .deps_stats(1, 2),
+        )
+        .printed_task(
+            &PrintableTask::new("a", 4, Blocked)
+                .action(Select)
+                .deps_stats(1, 3),
+        )
         .end();
 }
 
@@ -158,19 +217,26 @@ fn split_task_keep_with_budget() {
         .printed_task(
             &PrintableTask::new("x", 1, Incomplete)
                 .action(New)
-                .budget(Duration::hours(3)),
+                .budget(Duration::hours(3))
+                .adeps_stats(0, 1),
         )
         .printed_task(
             &PrintableTask::new("y", 2, Incomplete)
                 .action(New)
-                .budget(Duration::hours(3)),
+                .budget(Duration::hours(3))
+                .adeps_stats(0, 1),
         )
         .printed_task(
             &PrintableTask::new("z", 3, Incomplete)
                 .action(New)
-                .budget(Duration::hours(3)),
+                .budget(Duration::hours(3))
+                .adeps_stats(0, 1),
         )
-        .printed_task(&PrintableTask::new("a", 4, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("a", 4, Blocked)
+                .action(Select)
+                .deps_stats(3, 3),
+        )
         .end();
 }
 
@@ -184,19 +250,26 @@ fn split_task_chain_keep_with_budget() {
         .printed_task(
             &PrintableTask::new("x", 1, Incomplete)
                 .action(New)
-                .budget(Duration::hours(1)),
+                .budget(Duration::hours(1))
+                .adeps_stats(1, 3),
         )
         .printed_task(
             &PrintableTask::new("y", 2, Blocked)
                 .action(New)
-                .budget(Duration::hours(1)),
+                .budget(Duration::hours(1))
+                .deps_stats(1, 1),
         )
         .printed_task(
             &PrintableTask::new("z", 3, Blocked)
                 .action(New)
-                .budget(Duration::hours(1)),
+                .budget(Duration::hours(1))
+                .deps_stats(1, 2),
         )
-        .printed_task(&PrintableTask::new("a", 4, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("a", 4, Blocked)
+                .action(Select)
+                .deps_stats(1, 3),
+        )
         .end();
 }
 
@@ -240,16 +313,28 @@ fn split_tag_keep() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("x", 1, Incomplete).action(New).tag("a"),
+            &PrintableTask::new("x", 1, Incomplete)
+                .action(New)
+                .tag("a")
+                .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("y", 2, Incomplete).action(New).tag("a"),
+            &PrintableTask::new("y", 2, Incomplete)
+                .action(New)
+                .tag("a")
+                .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("z", 3, Incomplete).action(New).tag("a"),
+            &PrintableTask::new("z", 3, Incomplete)
+                .action(New)
+                .tag("a")
+                .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("a", 4, Blocked).action(Select).as_tag(),
+            &PrintableTask::new("a", 4, Blocked)
+                .action(Select)
+                .as_tag()
+                .deps_stats(3, 3),
         )
         .end();
 }
@@ -261,10 +346,26 @@ fn trim_leading_whitespace() {
     fix.test("todo split a --into ' a.x' '  a.y' '   a.z' --keep")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a.x", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a.y", 2, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a.z", 3, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a", 4, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("a.x", 1, Incomplete)
+                .action(New)
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("a.y", 2, Incomplete)
+                .action(New)
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("a.z", 3, Incomplete)
+                .action(New)
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("a", 4, Blocked)
+                .action(Select)
+                .deps_stats(3, 3),
+        )
         .end();
 }
 
@@ -275,9 +376,25 @@ fn trim_trailing_whitespace() {
     fix.test("todo split a --into 'a.x ' 'a.y  ' 'a.z   ' --keep")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a.x", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a.y", 2, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a.z", 3, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a", 4, Blocked).action(Select))
+        .printed_task(
+            &PrintableTask::new("a.x", 1, Incomplete)
+                .action(New)
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("a.y", 2, Incomplete)
+                .action(New)
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("a.z", 3, Incomplete)
+                .action(New)
+                .adeps_stats(0, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("a", 4, Blocked)
+                .action(Select)
+                .deps_stats(3, 3),
+        )
         .end();
 }

--- a/app/src/status_test.rs
+++ b/app/src/status_test.rs
@@ -33,7 +33,7 @@ fn status_does_not_include_blocked_tasks() {
     fix.test("todo")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
         .printed_task(&PrintableTask::new("c", 2, Incomplete))
         .end();
 }
@@ -46,8 +46,8 @@ fn include_blocked_in_status() {
     fix.test("todo -b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("a", 2, Blocked))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -73,8 +73,8 @@ fn include_all_in_status() {
         .modified(false)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Blocked))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&PrintableTask::new("c", 2, Blocked).deps_stats(1, 2))
         .end();
 }
 

--- a/app/src/tag_test.rs
+++ b/app/src/tag_test.rs
@@ -34,10 +34,20 @@ fn tag_show_blocked_tags() {
             &PrintableTask::new("a", 1, Incomplete)
                 .tag("c")
                 .tag("b")
-                .as_tag(),
+                .as_tag()
+                .adeps_stats(1, 2),
         )
-        .printed_task(&PrintableTask::new("b", 2, Blocked).tag("c").as_tag())
-        .printed_task(&PrintableTask::new("c", 3, Blocked).as_tag())
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .tag("c")
+                .as_tag()
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .as_tag()
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -126,10 +136,21 @@ fn tag_prints_affected_deps_when_marking() {
     fix.test("todo tag c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).tag("c"))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).tag("c"))
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked).action(Select).as_tag(),
+            &PrintableTask::new("a", 1, Incomplete)
+                .tag("c")
+                .adeps_stats(1, 2),
+        )
+        .printed_task(
+            &PrintableTask::new("b", 2, Blocked)
+                .tag("c")
+                .deps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 3, Blocked)
+                .action(Select)
+                .as_tag()
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -188,9 +209,16 @@ fn tag_does_not_show_complete_deps_by_default_when_marking() {
     fix.test("todo tag c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).tag("c"))
         .printed_task(
-            &PrintableTask::new("c", 2, Blocked).action(Select).as_tag(),
+            &PrintableTask::new("b", 1, Incomplete)
+                .tag("c")
+                .adeps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(Select)
+                .as_tag()
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -204,9 +232,16 @@ fn tag_show_complete_deps_when_marking() {
         .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete).tag("c"))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).tag("c"))
         .printed_task(
-            &PrintableTask::new("c", 2, Blocked).action(Select).as_tag(),
+            &PrintableTask::new("b", 1, Incomplete)
+                .tag("c")
+                .adeps_stats(1, 1),
+        )
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(Select)
+                .as_tag()
+                .deps_stats(1, 2),
         )
         .end();
 }
@@ -220,8 +255,12 @@ fn tag_does_not_show_complete_deps_by_default_when_unmarking() {
     fix.test("todo tag -u c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).action(Select))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -235,7 +274,11 @@ fn tag_show_complete_deps_when_unmarking() {
         .modified(true)
         .validate()
         .printed_task(&PrintableTask::new("a", 0, Complete))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).action(Select))
+        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(
+            &PrintableTask::new("c", 2, Blocked)
+                .action(Select)
+                .deps_stats(1, 2),
+        )
         .end();
 }

--- a/app/src/top_test.rs
+++ b/app/src/top_test.rs
@@ -31,7 +31,7 @@ fn top_all_tasks_categorized_the_same() {
     fix.test("todo top")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("d", 4, Blocked))
+        .printed_task(&PrintableTask::new("d", 4, Blocked).deps_stats(3, 3))
         .end();
 }
 
@@ -44,8 +44,8 @@ fn top_multiple_categories() {
     fix.test("todo top")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("g", 7, Blocked))
-        .printed_task(&PrintableTask::new("h", 8, Blocked))
+        .printed_task(&PrintableTask::new("g", 7, Blocked).deps_stats(3, 3))
+        .printed_task(&PrintableTask::new("h", 8, Blocked).deps_stats(3, 3))
         .end();
 }
 
@@ -57,8 +57,8 @@ fn top_deep_category() {
     fix.test("todo top")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("c", 5, Blocked))
-        .printed_task(&PrintableTask::new("f", 6, Blocked))
+        .printed_task(&PrintableTask::new("c", 5, Blocked).deps_stats(1, 2))
+        .printed_task(&PrintableTask::new("f", 6, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -111,8 +111,8 @@ fn top_underneath_one_task() {
     fix.test("todo top c")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("b", 2, Incomplete).adeps_stats(0, 1))
         .end();
 }
 
@@ -126,12 +126,12 @@ fn top_union_of_categories() {
     fix.test("todo top x y")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete))
-        .printed_task(&PrintableTask::new("d", 4, Incomplete))
-        .printed_task(&PrintableTask::new("e", 5, Incomplete))
-        .printed_task(&PrintableTask::new("f", 6, Incomplete))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("b", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("c", 3, Incomplete).adeps_stats(0, 2))
+        .printed_task(&PrintableTask::new("d", 4, Incomplete).adeps_stats(0, 2))
+        .printed_task(&PrintableTask::new("e", 5, Incomplete).adeps_stats(0, 1))
+        .printed_task(&PrintableTask::new("f", 6, Incomplete).adeps_stats(0, 1))
         .end();
 }
 
@@ -146,7 +146,7 @@ fn top_exclude_deps_with_indirect_connection_to_category() {
         // a should be excluded because there's also an indirect connection to
         // the top, through b. On the other hand, b is included because the only
         // path to the top is direct.
-        .printed_task(&PrintableTask::new("b", 2, Blocked))
+        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 

--- a/app/src/unblock_test.rs
+++ b/app/src/unblock_test.rs
@@ -85,9 +85,9 @@ fn unblock_from_all2() {
     fix.test("todo unblock c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
         .printed_task(&PrintableTask::new("c", 2, Incomplete).action(Unlock))
-        .printed_task(&PrintableTask::new("b", 3, Blocked))
+        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -134,10 +134,14 @@ fn unblock_updates_priority() {
         )
         // a and b have their priorities reset to 1.
         .printed_task(
-            &PrintableTask::new("a", 2, Incomplete).priority(Explicit(1)),
+            &PrintableTask::new("a", 2, Incomplete)
+                .priority(Explicit(1))
+                .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("b", 3, Blocked).priority(Explicit(1)),
+            &PrintableTask::new("b", 3, Blocked)
+                .priority(Explicit(1))
+                .deps_stats(1, 1),
         )
         .end();
 }
@@ -157,7 +161,9 @@ fn unblock_does_not_show_unaffected_priority() {
                 .priority(Explicit(1)),
         )
         .printed_task(
-            &PrintableTask::new("b", 3, Blocked).priority(Explicit(1)),
+            &PrintableTask::new("b", 3, Blocked)
+                .priority(Explicit(1))
+                .deps_stats(1, 1),
         )
         .end();
 }

--- a/printing/src/lib.rs
+++ b/printing/src/lib.rs
@@ -37,12 +37,15 @@ pub struct PrintableAppSuccess<'list> {
 pub type PrintableResult<'list> =
     Result<PrintableAppSuccess<'list>, Vec<PrintableError>>;
 
-pub trait Printable {
-    fn print(&self, printer: &mut impl TodoPrinter) -> bool;
+pub trait Printable<'a> {
+    fn print(&self, printer: &mut impl TodoPrinter<'a>) -> bool;
 }
 
-impl Printable for PrintableResult<'_> {
-    fn print(&self, printer: &mut impl TodoPrinter) -> bool {
+impl<'a, 'b> Printable<'a> for PrintableResult<'b>
+where
+    'b: 'a,
+{
+    fn print(&self, printer: &mut impl TodoPrinter<'a>) -> bool {
         match self {
             Self::Ok(PrintableAppSuccess {
                 warnings,

--- a/printing/src/scripting_todo_printer.rs
+++ b/printing/src/scripting_todo_printer.rs
@@ -8,8 +8,8 @@ use {
 
 pub struct ScriptingTodoPrinter;
 
-impl TodoPrinter for ScriptingTodoPrinter {
-    fn print_task(&mut self, task: &PrintableTask) {
+impl<'a> TodoPrinter<'a> for ScriptingTodoPrinter {
+    fn print_task(&mut self, task: &PrintableTask<'a>) {
         writeln!(std::io::stdout(), "{}", task.number).unwrap_or_default();
     }
 

--- a/printing/src/simple_todo_printer.rs
+++ b/printing/src/simple_todo_printer.rs
@@ -289,8 +289,8 @@ impl<'a> Display for PrintableTaskWithContext<'a> {
     }
 }
 
-impl<Out: Write> TodoPrinter for SimpleTodoPrinter<Out> {
-    fn print_task<'a>(&mut self, task: &PrintableTask<'a>) {
+impl<'a, Out: Write> TodoPrinter<'a> for SimpleTodoPrinter<Out> {
+    fn print_task(&mut self, task: &PrintableTask<'a>) {
         writeln!(
             self.out,
             "{}",

--- a/printing/src/todo_printer.rs
+++ b/printing/src/todo_printer.rs
@@ -1,7 +1,7 @@
 use super::*;
 
-pub trait TodoPrinter {
-    fn print_task(&mut self, task: &PrintableTask);
+pub trait TodoPrinter<'a> {
+    fn print_task(&mut self, task: &PrintableTask<'a>);
     fn print_info(&mut self, info: &PrintableInfo);
     fn print_warning(&mut self, warning: &PrintableWarning);
     fn print_error(&mut self, error: &PrintableError);


### PR DESCRIPTION
This avoids unnecessary copies in tests and avoids the need to separate
a "PrintedTaskInfo" struct from a "PrintableTask" struct.

This also straightens out the lifetime invariants of TodoPrinter.

We weren't comparing deps_stats and adeps_stats before, but now that
we're comparing PrintableTask objects directly, we have to specify the
full info in tests. This is why most of this change is updating tests.