### PR TITLE
Refactor printable tasks in tests.

### DIFF
--- a/app/src/block_test.rs
+++ b/app/src/block_test.rs
@@ -1,8 +1,8 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
     printing::{
-        Action::*, BriefPrintableTask, Plicit::*, PrintableError,
-        PrintableTask, Status::*,
+        Action::*, BriefPrintableTask, Plicit::*, PrintableError, Status::*,
     },
 };
 
@@ -13,12 +13,8 @@ fn block_one_on_one() {
     fix.test("todo block 1 --on 2")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).action(Lock).deps_stats(1, 1))
         .end();
 }
 
@@ -29,12 +25,8 @@ fn block_by_name() {
     fix.test("todo block a --on b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).action(Lock).deps_stats(1, 1))
         .end();
 }
 
@@ -45,14 +37,10 @@ fn block_one_on_three() {
     fix.test("todo block 1 --on 2 3 4")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("d", 3, Incomplete).adeps_stats(0, 1))
-        .printed_task(
-            &PrintableTask::new("a", 4, Blocked)
-                .action(Lock)
-                .deps_stats(3, 3),
-        )
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("c", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("d", 3, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("a", 4, Blocked).action(Lock).deps_stats(3, 3))
         .end();
 }
 
@@ -63,22 +51,10 @@ fn block_three_on_one() {
     fix.test("todo block 1 2 3 --on 4")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", 1, Incomplete).adeps_stats(3, 3))
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 3, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("d", 1, Incomplete).adeps_stats(3, 3))
+        .printed_task(&task("a", 2, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("b", 3, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("c", 4, Blocked).action(Lock).deps_stats(1, 1))
         .end();
 }
 
@@ -90,8 +66,8 @@ fn block_on_complete_task() {
     fix.test("todo block 1 --on -1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -1, Complete))
-        .printed_task(&PrintableTask::new("c", 1, Incomplete).action(Lock))
+        .printed_task(&task("a", -1, Complete))
+        .printed_task(&task("c", 1, Incomplete).action(Lock))
         .end();
 }
 
@@ -102,17 +78,9 @@ fn block_multiple_on_following_task() {
     fix.test("todo block 1 2 --on 3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("c", 1, Incomplete).adeps_stats(2, 2))
-        .printed_task(
-            &PrintableTask::new("a", 3, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("c", 1, Incomplete).adeps_stats(2, 2))
+        .printed_task(&task("a", 3, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("b", 4, Blocked).action(Lock).deps_stats(1, 1))
         .end();
 }
 
@@ -153,17 +121,15 @@ fn block_updates_implicit_priority_of_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 1),
+            &task("b", 2, Blocked).priority(Implicit(1)).deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .action(Lock)
                 .priority(Explicit(1))
                 .deps_stats(1, 2),
@@ -180,12 +146,10 @@ fn block_does_not_print_priority_updates_for_unaffected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .priority(Explicit(1))
-                .deps_stats(1, 1),
+            &task("b", 2, Blocked).priority(Explicit(1)).deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .action(Lock)
                 .priority(Explicit(1))
                 .deps_stats(1, 2),
@@ -203,12 +167,12 @@ fn block_excludes_complete_affected_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
+            &task("c", 2, Blocked)
                 .action(Lock)
                 .priority(Explicit(1))
                 .deps_stats(1, 2),
@@ -225,16 +189,14 @@ fn block_include_done() {
     fix.test("todo block c --on b -d")
         .modified(true)
         .validate()
+        .printed_task(&task("a", 0, Complete).priority(Implicit(1)))
         .printed_task(
-            &PrintableTask::new("a", 0, Complete).priority(Implicit(1)),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
+            &task("c", 2, Blocked)
                 .action(Lock)
                 .priority(Explicit(1))
                 .deps_stats(1, 2),
@@ -249,8 +211,8 @@ fn block_complete_task_on_preceding_complete_task() {
     fix.test("todo block b --on a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -1, Complete))
-        .printed_task(&PrintableTask::new("b", 0, Complete).action(Lock))
+        .printed_task(&task("a", -1, Complete))
+        .printed_task(&task("b", 0, Complete).action(Lock))
         .end();
 }
 
@@ -261,8 +223,8 @@ fn block_complete_task_on_distantly_preceding_complete_task() {
     fix.test("todo block e --on a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -4, Complete))
-        .printed_task(&PrintableTask::new("e", 0, Complete).action(Lock))
+        .printed_task(&task("a", -4, Complete))
+        .printed_task(&task("e", 0, Complete).action(Lock))
         .end();
 }
 
@@ -273,8 +235,8 @@ fn block_complete_task_on_later_complete_task() {
     fix.test("todo block a --on b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", -1, Complete))
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(Lock))
+        .printed_task(&task("b", -1, Complete))
+        .printed_task(&task("a", 0, Complete).action(Lock))
         .end();
 }
 
@@ -285,8 +247,8 @@ fn block_complete_task_on_distant_later_complete_task() {
     fix.test("todo block a --on e")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("e", -1, Complete))
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(Lock))
+        .printed_task(&task("e", -1, Complete))
+        .printed_task(&task("a", 0, Complete).action(Lock))
         .end();
 }
 
@@ -297,9 +259,9 @@ fn block_multiple_complete_tasks_on_later_complete_task() {
     fix.test("todo block a b --on d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", -2, Complete))
-        .printed_task(&PrintableTask::new("a", -1, Complete).action(Lock))
-        .printed_task(&PrintableTask::new("b", 0, Complete).action(Lock))
+        .printed_task(&task("d", -2, Complete))
+        .printed_task(&task("a", -1, Complete).action(Lock))
+        .printed_task(&task("b", 0, Complete).action(Lock))
         .end();
 }
 
@@ -312,7 +274,7 @@ fn redundant_block_does_not_modify() {
     fix.test("todo block b --on a")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Incomplete))
-        .printed_task(&PrintableTask::new("b", 1, Blocked).action(Lock))
+        .printed_task(&task("a", 0, Incomplete))
+        .printed_task(&task("b", 1, Blocked).action(Lock))
         .end();
 }

--- a/app/src/bottom_test.rs
+++ b/app/src/bottom_test.rs
@@ -1,7 +1,8 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
     lookup_key::Key,
-    printing::{PrintableTask, PrintableWarning, Status::*},
+    printing::{PrintableWarning, Status::*},
 };
 
 #[test]
@@ -17,9 +18,9 @@ fn bottom_all_tasks_uncategorized() {
     fix.test("todo bottom")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete))
+        .printed_task(&task("a", 1, Incomplete))
+        .printed_task(&task("b", 2, Incomplete))
+        .printed_task(&task("c", 3, Incomplete))
         .end();
 }
 
@@ -31,9 +32,9 @@ fn bottom_all_tasks_categorized_the_same() {
     fix.test("todo bottom")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("b", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("c", 3, Incomplete).adeps_stats(0, 1))
         .end();
 }
 
@@ -46,12 +47,12 @@ fn bottom_multiple_categories() {
     fix.test("todo bottom")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("d", 4, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("e", 5, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("f", 6, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("b", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("c", 3, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("d", 4, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("e", 5, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("f", 6, Incomplete).adeps_stats(0, 1))
         .end();
 }
 
@@ -63,8 +64,8 @@ fn bottom_deep_category() {
     fix.test("todo bottom")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(&PrintableTask::new("d", 2, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("d", 2, Incomplete).adeps_stats(1, 2))
         .end();
 }
 
@@ -76,8 +77,8 @@ fn bottom_does_not_show_complete_tasks_by_default() {
     fix.test("todo bottom")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete))
+        .printed_task(&task("b", 1, Incomplete))
+        .printed_task(&task("c", 2, Incomplete))
         .end();
 }
 
@@ -89,9 +90,9 @@ fn bottom_show_complete_tasks_with_option() {
     fix.test("todo bottom -d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete))
+        .printed_task(&task("a", 0, Complete))
+        .printed_task(&task("b", 1, Incomplete))
+        .printed_task(&task("c", 2, Incomplete))
         .end();
 }
 
@@ -104,8 +105,8 @@ fn bottom_show_only_bottom_level_complete_tasks() {
     fix.test("todo bottom -d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", -5, Complete))
-        .printed_task(&PrintableTask::new("d", -4, Complete))
+        .printed_task(&task("a", -5, Complete))
+        .printed_task(&task("d", -4, Complete))
         .end();
 }
 
@@ -124,7 +125,7 @@ fn bottom_above_blocking_task() {
     fix.test("todo bottom a")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -135,7 +136,7 @@ fn bottom_above_blocked_task() {
     fix.test("todo bottom b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("c", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&task("c", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -149,12 +150,12 @@ fn bottom_above_two_tasks() {
     fix.test("todo bottom x y")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 3, Blocked).deps_stats(1, 1))
-        .printed_task(&PrintableTask::new("b", 4, Blocked).deps_stats(1, 1))
-        .printed_task(&PrintableTask::new("c", 5, Blocked).deps_stats(2, 2))
-        .printed_task(&PrintableTask::new("d", 6, Blocked).deps_stats(2, 2))
-        .printed_task(&PrintableTask::new("e", 7, Blocked).deps_stats(1, 1))
-        .printed_task(&PrintableTask::new("f", 8, Blocked).deps_stats(1, 1))
+        .printed_task(&task("a", 3, Blocked).deps_stats(1, 1))
+        .printed_task(&task("b", 4, Blocked).deps_stats(1, 1))
+        .printed_task(&task("c", 5, Blocked).deps_stats(2, 2))
+        .printed_task(&task("d", 6, Blocked).deps_stats(2, 2))
+        .printed_task(&task("e", 7, Blocked).deps_stats(1, 1))
+        .printed_task(&task("f", 8, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -169,7 +170,7 @@ fn bottom_exclude_adeps_with_indirect_connection() {
         // b should be excluded because there's also an indirect connection to
         // it, through a. On the other hand, a is included because the only
         // path to it from the "bottom" task is direct.
-        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -194,6 +195,6 @@ fn bottom_implicit_include_done() {
     fix.test("todo bottom a")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 0, Complete))
+        .printed_task(&task("b", 0, Complete))
         .end();
 }

--- a/app/src/budget_test.rs
+++ b/app/src/budget_test.rs
@@ -1,11 +1,10 @@
 #![allow(clippy::zero_prefixed_literal)]
 
 use {
+    super::testing::task,
     super::testing::Fixture,
     chrono::Duration,
-    printing::{
-        Action::*, Plicit::*, PrintableError, PrintableTask, Status::*,
-    },
+    printing::{Action::*, Plicit::*, PrintableError, Status::*},
     testing::ymdhms,
 };
 
@@ -19,7 +18,7 @@ fn budget_one_task() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .due_date(Explicit(in_2_days))
                 .budget(Duration::days(1))
                 .action(Select),
@@ -35,17 +34,17 @@ fn budget_multiple_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .budget(Duration::days(2))
                 .action(Select),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Incomplete)
+            &task("c", 3, Incomplete)
                 .budget(Duration::days(2))
                 .action(Select),
         )
         .printed_task(
-            &PrintableTask::new("e", 5, Incomplete)
+            &task("e", 5, Incomplete)
                 .budget(Duration::days(2))
                 .action(Select),
         )
@@ -61,35 +60,35 @@ fn budget_chain_alters_due_dates() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 19, 59, 59)))
                 .budget(Duration::hours(1))
                 .action(Select)
                 .adeps_stats(1, 4),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
+            &task("b", 2, Blocked)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 20, 59, 59)))
                 .budget(Duration::hours(1))
                 .action(Select)
                 .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 21, 59, 59)))
                 .budget(Duration::hours(1))
                 .action(Select)
                 .deps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("d", 4, Blocked)
+            &task("d", 4, Blocked)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 22, 59, 59)))
                 .budget(Duration::hours(1))
                 .action(Select)
                 .deps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("e", 5, Blocked)
+            &task("e", 5, Blocked)
                 .due_date(Explicit(ymdhms(2021, 04, 29, 23, 59, 59)))
                 .budget(Duration::hours(1))
                 .action(Select)
@@ -107,17 +106,17 @@ fn budget_shows_affected_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 18, 00, 00)))
                 .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
+            &task("b", 2, Blocked)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 18, 00, 00)))
                 .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .due_date(Explicit(ymdhms(2021, 04, 29, 20, 00, 00)))
                 .budget(Duration::hours(2))
                 .action(Select)
@@ -136,12 +135,12 @@ fn budget_does_not_show_unaffected_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
+            &task("b", 2, Blocked)
                 .due_date(Implicit(ymdhms(2021, 04, 29, 18, 00, 00)))
                 .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .due_date(Explicit(ymdhms(2021, 04, 29, 20, 00, 00)))
                 .budget(Duration::hours(2))
                 .action(Select)
@@ -187,12 +186,12 @@ fn budget_does_not_include_complete_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .due_date(Implicit(ymdhms(2021, 04, 30, 22, 59, 59)))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
+            &task("c", 2, Blocked)
                 .due_date(Explicit(ymdhms(2021, 04, 30, 23, 59, 59)))
                 .budget(Duration::hours(1))
                 .action(Select)
@@ -210,16 +209,16 @@ fn budget_include_complete_affected_deps() {
     fix.test("todo budget c --is 1 hour -d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).punctuality(
+        .printed_task(&task("a", 0, Complete).punctuality(
             -chrono::Duration::hours(12) + chrono::Duration::seconds(1),
         ))
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .due_date(Implicit(ymdhms(2021, 04, 30, 22, 59, 59)))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
+            &task("c", 2, Blocked)
                 .due_date(Explicit(ymdhms(2021, 04, 30, 23, 59, 59)))
                 .budget(Duration::hours(1))
                 .action(Select)
@@ -235,6 +234,6 @@ fn budget_of_zero() {
     fix.test("todo budget a --is 0")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
+        .printed_task(&task("a", 1, Incomplete).action(Select))
         .end();
 }

--- a/app/src/chain_test.rs
+++ b/app/src/chain_test.rs
@@ -1,8 +1,8 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
     printing::{
-        Action::*, BriefPrintableTask, Plicit::*, PrintableError,
-        PrintableTask, Status::*,
+        Action::*, BriefPrintableTask, Plicit::*, PrintableError, Status::*,
     },
 };
 
@@ -20,17 +20,9 @@ fn chain_three() {
     fix.test("todo chain a b c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("b", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 5, Blocked)
-                .action(Lock)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("b", 4, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("c", 5, Blocked).action(Lock).deps_stats(1, 2))
         .end();
 }
 
@@ -57,17 +49,15 @@ fn chain_shows_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 1),
+            &task("b", 2, Blocked).priority(Implicit(1)).deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .priority(Explicit(1))
                 .action(Lock)
                 .deps_stats(1, 2),
@@ -85,12 +75,12 @@ fn chain_excludes_complete_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
+            &task("c", 2, Blocked)
                 .priority(Explicit(1))
                 .action(Lock)
                 .deps_stats(1, 2),
@@ -105,17 +95,9 @@ fn chain_by_range() {
     fix.test("todo chain 1..3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .action(Lock)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("b", 2, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).action(Lock).deps_stats(1, 2))
         .end();
 }
 
@@ -126,16 +108,8 @@ fn chain_ambiguous_key() {
     fix.test("todo chain a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("a", 3, Blocked)
-                .action(Lock)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("a", 2, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("a", 3, Blocked).action(Lock).deps_stats(1, 2))
         .end();
 }

--- a/app/src/check_test.rs
+++ b/app/src/check_test.rs
@@ -1,8 +1,9 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
     printing::{
-        Action::*, BriefPrintableTask, PrintableError, PrintableTask,
-        PrintableWarning, Status::*,
+        Action::*, BriefPrintableTask, PrintableError, PrintableWarning,
+        Status::*,
     },
 };
 
@@ -13,7 +14,7 @@ fn check_one_task() {
     fix.test("todo check 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
+        .printed_task(&task("a", 0, Complete).action(Check))
         .end();
 }
 
@@ -24,7 +25,7 @@ fn check_by_name() {
     fix.test("todo check b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 0, Complete).action(Check))
+        .printed_task(&task("b", 0, Complete).action(Check))
         .end();
 }
 
@@ -66,13 +67,13 @@ fn check_newly_unblocked_task() {
     fix.test("todo check 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 0, Complete).action(Check))
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Unlock))
+        .printed_task(&task("b", 0, Complete).action(Check))
+        .printed_task(&task("a", 1, Incomplete).action(Unlock))
         .end();
     fix.test("todo check 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
+        .printed_task(&task("a", 0, Complete).action(Check))
         .end();
 }
 
@@ -84,14 +85,14 @@ fn check_newly_unblocked_task_with_multiple_dependencies() {
     fix.test("todo check 1 2")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", -1, Complete).action(Check))
-        .printed_task(&PrintableTask::new("c", 0, Complete).action(Check))
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Unlock))
+        .printed_task(&task("b", -1, Complete).action(Check))
+        .printed_task(&task("c", 0, Complete).action(Check))
+        .printed_task(&task("a", 1, Incomplete).action(Unlock))
         .end();
     fix.test("todo check 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
+        .printed_task(&task("a", 0, Complete).action(Check))
         .end();
 }
 
@@ -104,23 +105,21 @@ fn check_newly_unblocked_task_with_chained_dependencies() {
     fix.test("todo check 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
+        .printed_task(&task("a", 0, Complete).action(Check))
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
-                .action(Unlock)
-                .adeps_stats(1, 1),
+            &task("b", 1, Incomplete).action(Unlock).adeps_stats(1, 1),
         )
         .end();
     fix.test("todo check 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 0, Complete).action(Check))
-        .printed_task(&PrintableTask::new("c", 1, Incomplete).action(Unlock))
+        .printed_task(&task("b", 0, Complete).action(Check))
+        .printed_task(&task("c", 1, Incomplete).action(Unlock))
         .end();
     fix.test("todo check 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("c", 0, Complete).action(Check))
+        .printed_task(&task("c", 0, Complete).action(Check))
         .end();
 }
 
@@ -132,11 +131,9 @@ fn check_does_not_show_adeps_that_are_not_unlocked() {
     fix.test("todo check 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
+        .printed_task(&task("a", 0, Complete).action(Check))
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
-                .action(Unlock)
-                .adeps_stats(1, 1),
+            &task("b", 1, Incomplete).action(Unlock).adeps_stats(1, 1),
         )
         // Do not print c, even though it's a direct adep, because it has not
         // been unlocked.
@@ -150,7 +147,7 @@ fn check_same_task_twice_in_one_command() {
     fix.test("todo check 1 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
+        .printed_task(&task("a", 0, Complete).action(Check))
         .end();
 }
 
@@ -175,7 +172,7 @@ fn force_check_incomplete_task() {
     fix.test("todo check a --force")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(Check))
+        .printed_task(&task("a", 0, Complete).action(Check))
         .end();
 }
 
@@ -186,8 +183,8 @@ fn force_check_blocked_task() {
     fix.test("todo check b --force")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -1, Complete).action(Check))
-        .printed_task(&PrintableTask::new("b", 0, Complete).action(Check))
+        .printed_task(&task("a", -1, Complete).action(Check))
+        .printed_task(&task("b", 0, Complete).action(Check))
         .end();
 }
 
@@ -198,9 +195,9 @@ fn force_check_transitively_blocked_task() {
     fix.test("todo check c --force")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -2, Complete).action(Check))
-        .printed_task(&PrintableTask::new("b", -1, Complete).action(Check))
-        .printed_task(&PrintableTask::new("c", 0, Complete).action(Check))
+        .printed_task(&task("a", -2, Complete).action(Check))
+        .printed_task(&task("b", -1, Complete).action(Check))
+        .printed_task(&task("c", 0, Complete).action(Check))
         .end();
 }
 
@@ -213,8 +210,8 @@ fn force_check_task_with_complete_deps() {
     fix.test("todo check c --force")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", -1, Complete).action(Check))
-        .printed_task(&PrintableTask::new("c", 0, Complete).action(Check))
+        .printed_task(&task("b", -1, Complete).action(Check))
+        .printed_task(&task("c", 0, Complete).action(Check))
         .end();
 }
 
@@ -239,8 +236,8 @@ fn check_blocking_chain() {
     fix.test("todo check a b c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -2, Complete).action(Check))
-        .printed_task(&PrintableTask::new("b", -1, Complete).action(Check))
-        .printed_task(&PrintableTask::new("c", 0, Complete).action(Check))
+        .printed_task(&task("a", -2, Complete).action(Check))
+        .printed_task(&task("b", -1, Complete).action(Check))
+        .printed_task(&task("c", 0, Complete).action(Check))
         .end();
 }

--- a/app/src/due_test.rs
+++ b/app/src/due_test.rs
@@ -1,8 +1,9 @@
 #![allow(clippy::zero_prefixed_literal)]
 
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{Plicit::*, PrintableError, PrintableTask, Status::*},
+    printing::{Plicit::*, PrintableError, Status::*},
     testing::ymdhms,
 };
 
@@ -16,18 +17,9 @@ fn show_tasks_with_due_date() {
     fix.test("todo due")
         .modified(false)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .due_date(Explicit(in_1_day)),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 2, Incomplete)
-                .due_date(Explicit(in_1_day)),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 3, Incomplete)
-                .due_date(Explicit(in_1_day)),
-        )
+        .printed_task(&task("a", 1, Incomplete).due_date(Explicit(in_1_day)))
+        .printed_task(&task("b", 2, Incomplete).due_date(Explicit(in_1_day)))
+        .printed_task(&task("c", 3, Incomplete).due_date(Explicit(in_1_day)))
         .end();
 }
 
@@ -45,17 +37,17 @@ fn show_tasks_with_due_date_includes_blocked() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .due_date(Explicit(in_5_hours))
                 .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 5, Blocked)
+            &task("b", 5, Blocked)
                 .due_date(Implicit(in_2_days))
                 .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 6, Blocked)
+            &task("c", 6, Blocked)
                 .due_date(Explicit(in_2_days))
                 .deps_stats(1, 2),
         )
@@ -76,12 +68,12 @@ fn show_tasks_with_due_date_excludes_complete() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .due_date(Implicit(in_2_days))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 5, Blocked)
+            &task("c", 5, Blocked)
                 .due_date(Explicit(in_2_days))
                 .deps_stats(1, 2),
         )
@@ -102,16 +94,15 @@ fn show_tasks_with_due_date_include_done() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 0, Complete)
-                .punctuality(-chrono::Duration::hours(5)),
+            &task("a", 0, Complete).punctuality(-chrono::Duration::hours(5)),
         )
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .due_date(Implicit(in_2_days))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 5, Blocked)
+            &task("c", 5, Blocked)
                 .due_date(Explicit(in_2_days))
                 .deps_stats(1, 2),
         )
@@ -133,14 +124,11 @@ fn show_tasks_with_due_date_earlier_than_given_date() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .due_date(Explicit(in_5_hours))
                 .adeps_stats(1, 2),
         )
-        .printed_task(
-            &PrintableTask::new("g", 2, Incomplete)
-                .due_date(Explicit(in_6_hours)),
-        )
+        .printed_task(&task("g", 2, Incomplete).due_date(Explicit(in_6_hours)))
         .end();
 }
 
@@ -159,11 +147,10 @@ fn show_tasks_with_due_date_earlier_than_given_date_include_done() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("g", 0, Complete)
-                .punctuality(-chrono::Duration::hours(6)),
+            &task("g", 0, Complete).punctuality(-chrono::Duration::hours(6)),
         )
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .due_date(Explicit(in_5_hours))
                 .adeps_stats(1, 2),
         )
@@ -183,17 +170,17 @@ fn show_source_of_implicit_due_date() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 4, Incomplete)
+            &task("a", 4, Incomplete)
                 .due_date(Implicit(in_2_days))
                 .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 5, Blocked)
+            &task("b", 5, Blocked)
                 .due_date(Implicit(in_2_days))
                 .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 6, Blocked)
+            &task("c", 6, Blocked)
                 .due_date(Explicit(in_2_days))
                 .deps_stats(1, 2),
         )
@@ -212,14 +199,8 @@ fn set_due_date() {
     fix.test("todo due d e --on thursday")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("d", 2, Incomplete)
-                .due_date(Explicit(thursday)),
-        )
-        .printed_task(
-            &PrintableTask::new("e", 3, Incomplete)
-                .due_date(Explicit(thursday)),
-        )
+        .printed_task(&task("d", 2, Incomplete).due_date(Explicit(thursday)))
+        .printed_task(&task("e", 3, Incomplete).due_date(Explicit(thursday)))
         .end();
 }
 
@@ -233,10 +214,7 @@ fn set_due_date_excludes_complete_tasks() {
     fix.test("todo due b --on thursday")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
-                .due_date(Explicit(thursday)),
-        )
+        .printed_task(&task("b", 1, Incomplete).due_date(Explicit(thursday)))
         .end();
 }
 
@@ -252,13 +230,8 @@ fn set_due_date_include_done() {
     fix.test("todo due b --on thursday --include-done")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 0, Complete).punctuality(punctuality),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
-                .due_date(Explicit(thursday)),
-        )
+        .printed_task(&task("a", 0, Complete).punctuality(punctuality))
+        .printed_task(&task("b", 1, Incomplete).due_date(Explicit(thursday)))
         .end();
 }
 
@@ -275,17 +248,17 @@ fn set_due_date_prints_affected_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .due_date(Implicit(in_1_hour))
                 .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 5, Blocked)
+            &task("b", 5, Blocked)
                 .due_date(Implicit(in_1_hour))
                 .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 6, Blocked)
+            &task("c", 6, Blocked)
                 .due_date(Explicit(in_1_hour))
                 .deps_stats(1, 2),
         )
@@ -302,8 +275,8 @@ fn reset_due_date() {
     fix.test("todo due c --none")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 5, Blocked).deps_stats(1, 1))
-        .printed_task(&PrintableTask::new("c", 6, Blocked).deps_stats(1, 2))
+        .printed_task(&task("b", 5, Blocked).deps_stats(1, 1))
+        .printed_task(&task("c", 6, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -316,9 +289,9 @@ fn show_tasks_without_due_dates() {
     fix.test("todo due --none")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("g", 4, Incomplete).adeps_stats(1, 2))
-        .printed_task(&PrintableTask::new("h", 8, Blocked).deps_stats(1, 1))
-        .printed_task(&PrintableTask::new("i", 9, Blocked).deps_stats(1, 2))
+        .printed_task(&task("g", 4, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("h", 8, Blocked).deps_stats(1, 1))
+        .printed_task(&task("i", 9, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -331,8 +304,8 @@ fn show_tasks_without_due_date_excludes_complete() {
     fix.test("todo due --none")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("e", 4, Incomplete).adeps_stats(1, 1))
-        .printed_task(&PrintableTask::new("f", 5, Blocked).deps_stats(1, 2))
+        .printed_task(&task("e", 4, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("f", 5, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -345,9 +318,9 @@ fn show_tasks_without_due_date_include_done() {
     fix.test("todo due --none -d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("d", 0, Complete))
-        .printed_task(&PrintableTask::new("e", 4, Incomplete).adeps_stats(1, 1))
-        .printed_task(&PrintableTask::new("f", 5, Blocked).deps_stats(1, 2))
+        .printed_task(&task("d", 0, Complete))
+        .printed_task(&task("e", 4, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("f", 5, Blocked).deps_stats(1, 2))
         .end();
 }
 

--- a/app/src/edit_test.rs
+++ b/app/src/edit_test.rs
@@ -1,6 +1,7 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{PrintableError, PrintableTask, Status::*},
+    printing::{PrintableError, Status::*},
     text_editing::FakeTextEditor,
 };
 
@@ -11,7 +12,7 @@ fn edit_one_task() {
     fix.test("todo edit 1 --desc b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&task("b", 1, Incomplete))
         .end();
 }
 
@@ -22,9 +23,9 @@ fn edit_multiple_tasks() {
     fix.test("todo edit 1 2 3 --desc d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", 1, Incomplete))
-        .printed_task(&PrintableTask::new("d", 2, Incomplete))
-        .printed_task(&PrintableTask::new("d", 3, Incomplete))
+        .printed_task(&task("d", 1, Incomplete))
+        .printed_task(&task("d", 2, Incomplete))
+        .printed_task(&task("d", 3, Incomplete))
         .end();
 }
 
@@ -36,7 +37,7 @@ fn edit_with_text_editor_happy_path() {
     fix.test("todo edit 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&task("b", 1, Incomplete))
         .end();
     assert_eq!(*fix.text_editor.recorded_input(), "1) a");
 }
@@ -49,7 +50,7 @@ fn edit_with_text_editor_long_desc_later_task() {
     fix.test("todo edit 3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("this is serious", 3, Incomplete))
+        .printed_task(&task("this is serious", 3, Incomplete))
         .end();
     assert_eq!(*fix.text_editor.recorded_input(), "3) c");
 }
@@ -62,9 +63,9 @@ fn edit_multiple_tasks_with_text_editor() {
     fix.test("todo edit 1 2 3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", 1, Incomplete))
-        .printed_task(&PrintableTask::new("e", 2, Incomplete))
-        .printed_task(&PrintableTask::new("f", 3, Incomplete))
+        .printed_task(&task("d", 1, Incomplete))
+        .printed_task(&task("e", 2, Incomplete))
+        .printed_task(&task("f", 3, Incomplete))
         .end();
     assert_eq!(*fix.text_editor.recorded_input(), "1) a\n2) b\n3) c");
 }
@@ -148,7 +149,7 @@ fn trim_leading_whitespace_from_desc_from_text_editor() {
     fix.test("todo edit 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&task("b", 1, Incomplete))
         .end();
 }
 
@@ -160,7 +161,7 @@ fn trim_trailing_whitespace_from_desc_from_text_editor() {
     fix.test("todo edit 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&task("b", 1, Incomplete))
         .end();
 }
 
@@ -172,9 +173,9 @@ fn trim_whitespace_from_desc_from_text_editor_with_multiple_tasks() {
     fix.test("todo edit 1 2 3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", 1, Incomplete))
-        .printed_task(&PrintableTask::new("e", 2, Incomplete))
-        .printed_task(&PrintableTask::new("f", 3, Incomplete))
+        .printed_task(&task("d", 1, Incomplete))
+        .printed_task(&task("e", 2, Incomplete))
+        .printed_task(&task("f", 3, Incomplete))
         .end();
 }
 
@@ -185,7 +186,7 @@ fn trim_leading_whitespace_from_command_line() {
     fix.test("todo edit 1 --desc '  b'")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&task("b", 1, Incomplete))
         .end();
 }
 
@@ -196,6 +197,6 @@ fn trim_trailing_whitespace_from_command_line() {
     fix.test("todo edit 1 --desc 'b  '")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&task("b", 1, Incomplete))
         .end();
 }

--- a/app/src/find_test.rs
+++ b/app/src/find_test.rs
@@ -1,6 +1,7 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{Action::Select, PrintableTask, Status::*},
+    printing::{Action::Select, Status::*},
 };
 
 #[test]
@@ -10,7 +11,7 @@ fn find_with_exact_match() {
     fix.test("todo find b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Select))
+        .printed_task(&task("b", 2, Incomplete).action(Select))
         .end();
 }
 
@@ -21,7 +22,7 @@ fn find_with_substring_match() {
     fix.test("todo find b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("aba", 2, Incomplete).action(Select))
+        .printed_task(&task("aba", 2, Incomplete).action(Select))
         .end();
 }
 
@@ -32,9 +33,9 @@ fn find_with_multiple_matches() {
     fix.test("todo find a")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("aaa", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("aba", 2, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("aca", 3, Incomplete).action(Select))
+        .printed_task(&task("aaa", 1, Incomplete).action(Select))
+        .printed_task(&task("aba", 2, Incomplete).action(Select))
+        .printed_task(&task("aca", 3, Incomplete).action(Select))
         .end();
 }
 
@@ -54,7 +55,7 @@ fn find_includes_complete_tasks() {
     fix.test("todo find b -d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("aba", 0, Complete).action(Select))
+        .printed_task(&task("aba", 0, Complete).action(Select))
         .end();
 }
 
@@ -65,11 +66,7 @@ fn find_includes_blocked_tasks() {
     fix.test("todo find b")
         .modified(false)
         .validate()
-        .printed_task(
-            &PrintableTask::new("aba", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("aba", 2, Blocked).action(Select).deps_stats(1, 1))
         .end();
 }
 
@@ -80,8 +77,8 @@ fn find_case_insensitive() {
     fix.test("todo find aa")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("AAA", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("aaa", 2, Incomplete).action(Select))
+        .printed_task(&task("AAA", 1, Incomplete).action(Select))
+        .printed_task(&task("aaa", 2, Incomplete).action(Select))
         .end();
 }
 
@@ -94,23 +91,11 @@ fn find_includes_matches_with_tag() {
     fix.test("todo find g")
         .modified(false)
         .validate()
+        .printed_task(&task("a", 4, Incomplete).tag("g").adeps_stats(0, 1))
+        .printed_task(&task("b", 5, Incomplete).tag("g").adeps_stats(0, 1))
+        .printed_task(&task("c", 6, Incomplete).tag("g").adeps_stats(0, 1))
         .printed_task(
-            &PrintableTask::new("a", 4, Incomplete)
-                .tag("g")
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 5, Incomplete)
-                .tag("g")
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 6, Incomplete)
-                .tag("g")
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("g", 7, Blocked)
+            &task("g", 7, Blocked)
                 .as_tag()
                 .action(Select)
                 .deps_stats(3, 3),
@@ -128,11 +113,7 @@ fn find_includes_matches_with_tag_excludes_complete() {
     fix.test("todo find g")
         .modified(false)
         .validate()
-        .printed_task(
-            &PrintableTask::new("g", 1, Incomplete)
-                .as_tag()
-                .action(Select),
-        )
+        .printed_task(&task("g", 1, Incomplete).as_tag().action(Select))
         .end();
 }
 
@@ -146,14 +127,10 @@ fn find_includes_matches_with_tag_include_complete() {
     fix.test("todo find g -d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", -5, Complete).tag("g"))
-        .printed_task(&PrintableTask::new("b", -4, Complete).tag("g"))
-        .printed_task(&PrintableTask::new("c", -3, Complete).tag("g"))
-        .printed_task(
-            &PrintableTask::new("g", 1, Incomplete)
-                .as_tag()
-                .action(Select),
-        )
+        .printed_task(&task("a", -5, Complete).tag("g"))
+        .printed_task(&task("b", -4, Complete).tag("g"))
+        .printed_task(&task("c", -3, Complete).tag("g"))
+        .printed_task(&task("g", 1, Incomplete).as_tag().action(Select))
         .end();
 }
 
@@ -165,23 +142,11 @@ fn find_incomplete_matches_with_tag() {
     fix.test("todo find gg")
         .modified(false)
         .validate()
+        .printed_task(&task("a", 4, Incomplete).tag("ggg").adeps_stats(0, 1))
+        .printed_task(&task("b", 5, Incomplete).tag("ggg").adeps_stats(0, 1))
+        .printed_task(&task("c", 6, Incomplete).tag("ggg").adeps_stats(0, 1))
         .printed_task(
-            &PrintableTask::new("a", 4, Incomplete)
-                .tag("ggg")
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 5, Incomplete)
-                .tag("ggg")
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 6, Incomplete)
-                .tag("ggg")
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("ggg", 7, Blocked)
+            &task("ggg", 7, Blocked)
                 .as_tag()
                 .action(Select)
                 .deps_stats(3, 3),

--- a/app/src/get_test.rs
+++ b/app/src/get_test.rs
@@ -1,6 +1,7 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, PrintableTask, Status::*},
+    printing::{Action::*, Status::*},
 };
 
 #[test]
@@ -10,7 +11,7 @@ fn get_incomplete_task() {
     fix.test("todo get 2")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Select))
+        .printed_task(&task("b", 2, Incomplete).action(Select))
         .end();
 }
 
@@ -22,7 +23,7 @@ fn get_complete_task() {
     fix.test("todo get -2")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", -2, Complete).action(Select))
+        .printed_task(&task("a", -2, Complete).action(Select))
         .end();
 }
 
@@ -33,9 +34,9 @@ fn get_multiple_tasks() {
     fix.test("todo get 2 3 4")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("d", 4, Incomplete).action(Select))
+        .printed_task(&task("b", 2, Incomplete).action(Select))
+        .printed_task(&task("c", 3, Incomplete).action(Select))
+        .printed_task(&task("d", 4, Incomplete).action(Select))
         .end();
 }
 
@@ -47,7 +48,7 @@ fn get_excludes_completed_deps() {
     fix.test("todo get b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).action(Select))
+        .printed_task(&task("b", 1, Incomplete).action(Select))
         .end();
 }
 
@@ -59,8 +60,8 @@ fn get_include_done() {
     fix.test("todo get b -d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).action(Select))
+        .printed_task(&task("a", 0, Complete))
+        .printed_task(&task("b", 1, Incomplete).action(Select))
         .end();
 }
 
@@ -72,12 +73,8 @@ fn get_shows_blocking_tasks() {
     fix.test("todo get 2")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
         .end();
 }
 
@@ -90,11 +87,9 @@ fn get_shows_blocked_tasks() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .adeps_stats(1, 1),
+            &task("a", 1, Incomplete).action(Select).adeps_stats(1, 1),
         )
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -105,15 +100,11 @@ fn get_shows_transitive_deps_and_adeps() {
     fix.test("todo get 3")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 4))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .action(Select)
-                .deps_stats(1, 2),
-        )
-        .printed_task(&PrintableTask::new("d", 4, Blocked).deps_stats(1, 3))
-        .printed_task(&PrintableTask::new("e", 5, Blocked).deps_stats(1, 4))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 4))
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).action(Select).deps_stats(1, 2))
+        .printed_task(&task("d", 4, Blocked).deps_stats(1, 3))
+        .printed_task(&task("e", 5, Blocked).deps_stats(1, 4))
         .end();
 }
 
@@ -124,8 +115,8 @@ fn get_by_name_multiple_matches() {
     fix.test("todo get bob")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("bob", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("bob", 3, Incomplete).action(Select))
+        .printed_task(&task("bob", 1, Incomplete).action(Select))
+        .printed_task(&task("bob", 3, Incomplete).action(Select))
         .end();
 }
 
@@ -137,9 +128,7 @@ fn get_no_context_single_task_by_name() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .adeps_stats(1, 2),
+            &task("a", 1, Incomplete).action(Select).adeps_stats(1, 2),
         )
         .end();
 }
@@ -152,15 +141,9 @@ fn get_no_context_multiple_tasks_by_name() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .adeps_stats(1, 2),
+            &task("a", 1, Incomplete).action(Select).adeps_stats(1, 2),
         )
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
         .end();
 }
 
@@ -172,7 +155,7 @@ fn get_no_context_single_completed_task() {
     fix.test("todo get a -n")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", -2, Complete).action(Select))
+        .printed_task(&task("a", -2, Complete).action(Select))
         .end();
 }
 
@@ -184,8 +167,8 @@ fn get_no_context_multiple_completed_tasks() {
     fix.test("todo get a b -n")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", -2, Complete).action(Select))
-        .printed_task(&PrintableTask::new("b", -1, Complete).action(Select))
+        .printed_task(&task("a", -2, Complete).action(Select))
+        .printed_task(&task("b", -1, Complete).action(Select))
         .end();
 }
 
@@ -196,11 +179,7 @@ fn get_no_context_blocked_task() {
     fix.test("todo get c -n")
         .modified(false)
         .validate()
-        .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .action(Select)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("c", 3, Blocked).action(Select).deps_stats(1, 2))
         .end();
 }
 
@@ -212,12 +191,8 @@ fn get_no_context_complete_and_incomplete_match() {
     fix.test("todo get a -n")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(Select))
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("a", 0, Complete).action(Select))
+        .printed_task(&task("a", 2, Blocked).action(Select).deps_stats(1, 2))
         .end();
 }
 
@@ -228,12 +203,8 @@ fn get_blocked_by_one_task() {
     fix.test("todo get --blocked-by b")
         .modified(false)
         .validate()
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("c", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -244,14 +215,10 @@ fn get_blocked_by_shows_transitive_adeps() {
     fix.test("todo get --blocked-by b")
         .modified(false)
         .validate()
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("c", 3, Blocked).deps_stats(1, 2))
-        .printed_task(&PrintableTask::new("d", 4, Blocked).deps_stats(1, 3))
-        .printed_task(&PrintableTask::new("e", 5, Blocked).deps_stats(1, 4))
+        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&task("d", 4, Blocked).deps_stats(1, 3))
+        .printed_task(&task("e", 5, Blocked).deps_stats(1, 4))
         .end();
 }
 
@@ -262,12 +229,8 @@ fn get_blocking_one_task() {
     fix.test("todo get --blocking b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
         .end();
 }
 
@@ -278,13 +241,9 @@ fn get_blocking_shows_transitive_deps() {
     fix.test("todo get --blocking d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 4))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(&PrintableTask::new("c", 3, Blocked).deps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("d", 4, Blocked)
-                .action(Select)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 4))
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&task("d", 4, Blocked).action(Select).deps_stats(1, 3))
         .end();
 }

--- a/app/src/log_test.rs
+++ b/app/src/log_test.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::zero_prefixed_literal)]
 
 use {
+    super::testing::task,
     super::testing::Fixture,
     chrono::{Local, TimeZone, Utc},
-    printing::{LogDate::*, PrintableTask, Status::*},
+    printing::{LogDate::*, Status::*},
 };
 
 #[test]
@@ -22,8 +23,7 @@ fn log_after_single_task_completed() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 0, Complete)
-                .log_date(YearMonthDay(2021, 03, 26)),
+            &task("b", 0, Complete).log_date(YearMonthDay(2021, 03, 26)),
         )
         .end();
 }
@@ -38,11 +38,10 @@ fn log_after_multiple_tasks_completed() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("c", 0, Complete)
-                .log_date(YearMonthDay(2021, 03, 26)),
+            &task("c", 0, Complete).log_date(YearMonthDay(2021, 03, 26)),
         )
         .printed_task(
-            &PrintableTask::new("a", -1, Complete)
+            &task("a", -1, Complete)
                 // Don't repeat the log date if it's the same.
                 .log_date(Invisible),
         )
@@ -67,18 +66,12 @@ fn log_shows_date_when_it_changes() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("d", 0, Complete)
-                .log_date(YearMonthDay(2021, 01, 02)),
+            &task("d", 0, Complete).log_date(YearMonthDay(2021, 01, 02)),
         )
+        .printed_task(&task("c", -1, Complete).log_date(Invisible))
         .printed_task(
-            &PrintableTask::new("c", -1, Complete).log_date(Invisible),
+            &task("b", -2, Complete).log_date(YearMonthDay(2021, 01, 01)),
         )
-        .printed_task(
-            &PrintableTask::new("b", -2, Complete)
-                .log_date(YearMonthDay(2021, 01, 01)),
-        )
-        .printed_task(
-            &PrintableTask::new("a", -3, Complete).log_date(Invisible),
-        )
+        .printed_task(&task("a", -3, Complete).log_date(Invisible))
         .end();
 }

--- a/app/src/merge_test.rs
+++ b/app/src/merge_test.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::zero_prefixed_literal)]
 
 use {
+    super::testing::task,
     super::testing::Fixture,
     printing::{
-        Action::*, BriefPrintableTask, Plicit::*, PrintableError,
-        PrintableTask, Status::*,
+        Action::*, BriefPrintableTask, Plicit::*, PrintableError, Status::*,
     },
     testing::ymdhms,
 };
@@ -16,7 +16,7 @@ fn merge_two_tasks() {
     fix.test("todo merge a b --into ab")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("ab", 2, Incomplete).action(Select))
+        .printed_task(&task("ab", 2, Incomplete).action(Select))
         .end();
 }
 
@@ -27,7 +27,7 @@ fn merge_three_tasks() {
     fix.test("todo merge a b c --into abc")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("abc", 1, Incomplete).action(Select))
+        .printed_task(&task("abc", 1, Incomplete).action(Select))
         .end();
 }
 
@@ -38,12 +38,8 @@ fn merge_preserves_deps() {
     fix.test("todo merge b c --into bc")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("bc", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("bc", 2, Blocked).action(Select).deps_stats(1, 1))
         .end();
 }
 
@@ -55,11 +51,9 @@ fn merge_preserves_adeps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("ab", 1, Incomplete)
-                .action(Select)
-                .adeps_stats(1, 1),
+            &task("ab", 1, Incomplete).action(Select).adeps_stats(1, 1),
         )
-        .printed_task(&PrintableTask::new("c", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("c", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -70,13 +64,9 @@ fn merge_preserves_deps_and_adeps() {
     fix.test("todo merge b c d --into bcd")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("bcd", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("e", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("bcd", 2, Blocked).action(Select).deps_stats(1, 1))
+        .printed_task(&task("e", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -92,7 +82,7 @@ fn merged_task_has_min_due_date_of_sources() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("abc", 1, Incomplete)
+            &task("abc", 1, Incomplete)
                 .action(Select)
                 .due_date(Explicit(in_10_min)),
         )
@@ -110,7 +100,7 @@ fn merged_task_has_max_priority_of_sources() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("abcd", 1, Incomplete)
+            &task("abcd", 1, Incomplete)
                 .action(Select)
                 .priority(Explicit(2)),
         )
@@ -158,13 +148,9 @@ fn merge_inside_chain() {
     fix.test("todo merge c d --into cd")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("cd", 3, Blocked)
-                .action(Select)
-                .deps_stats(1, 2),
-        )
-        .printed_task(&PrintableTask::new("e", 4, Blocked).deps_stats(1, 3))
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("cd", 3, Blocked).action(Select).deps_stats(1, 2))
+        .printed_task(&task("e", 4, Blocked).deps_stats(1, 3))
         .end();
 }
 
@@ -178,7 +164,7 @@ fn merge_task_with_snoozed_task() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("ab", 1, Blocked)
+            &task("ab", 1, Blocked)
                 .action(Select)
                 .start_date(ymdhms(2021, 05, 29, 00, 00, 00)),
         )
@@ -197,7 +183,7 @@ fn merge_snoozed_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("abc", 1, Blocked)
+            &task("abc", 1, Blocked)
                 .action(Select)
                 .start_date(ymdhms(2021, 05, 28, 19, 00, 00)),
         )
@@ -211,11 +197,7 @@ fn merge_tags_default() {
     fix.test("todo merge a b c --into abc")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("abc", 1, Incomplete)
-                .action(Select)
-                .as_tag(),
-        )
+        .printed_task(&task("abc", 1, Incomplete).action(Select).as_tag())
         .end();
 }
 
@@ -226,11 +208,7 @@ fn merge_tags_into_tag() {
     fix.test("todo merge a b c --into abc --tag true")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("abc", 1, Incomplete)
-                .action(Select)
-                .as_tag(),
-        )
+        .printed_task(&task("abc", 1, Incomplete).action(Select).as_tag())
         .end();
 }
 
@@ -241,11 +219,7 @@ fn merge_tasks_into_tag() {
     fix.test("todo merge a b c --into abc --tag true")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("abc", 1, Incomplete)
-                .action(Select)
-                .as_tag(),
-        )
+        .printed_task(&task("abc", 1, Incomplete).action(Select).as_tag())
         .end();
 }
 
@@ -256,7 +230,7 @@ fn merge_tags_into_task() {
     fix.test("todo merge a b c --into abc --tag false")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("abc", 1, Incomplete).action(Select))
+        .printed_task(&task("abc", 1, Incomplete).action(Select))
         .end();
 }
 
@@ -269,17 +243,13 @@ fn show_tags_for_merged_task() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("ab", 1, Incomplete)
+            &task("ab", 1, Incomplete)
                 .action(Select)
                 .as_tag()
                 .tag("c")
                 .adeps_stats(1, 1),
         )
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
-                .as_tag()
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("c", 2, Blocked).as_tag().deps_stats(1, 1))
         .end();
 }
 
@@ -290,7 +260,7 @@ fn trim_leading_whitespace_from_desc() {
     fix.test("todo merge a b c --into '  abc'")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("abc", 1, Incomplete).action(Select))
+        .printed_task(&task("abc", 1, Incomplete).action(Select))
         .end();
 }
 
@@ -301,7 +271,7 @@ fn trim_trailing_whitespace_from_desc() {
     fix.test("todo merge a b c --into 'abc  '")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("abc", 1, Incomplete).action(Select))
+        .printed_task(&task("abc", 1, Incomplete).action(Select))
         .end();
 }
 
@@ -312,6 +282,6 @@ fn trim_leading_and_trailing_whitespace_from_desc() {
     fix.test("todo merge a b c --into '  abc  '")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("abc", 1, Incomplete).action(Select))
+        .printed_task(&task("abc", 1, Incomplete).action(Select))
         .end();
 }

--- a/app/src/new_test.rs
+++ b/app/src/new_test.rs
@@ -1,11 +1,11 @@
 #![allow(clippy::zero_prefixed_literal)]
 
 use {
+    super::testing::task,
     super::testing::Fixture,
     chrono::Duration,
     printing::{
-        Action::*, BriefPrintableTask, Plicit::*, PrintableError,
-        PrintableTask, Status::*,
+        Action::*, BriefPrintableTask, Plicit::*, PrintableError, Status::*,
     },
     testing::ymdhms,
 };
@@ -16,7 +16,7 @@ fn new_one_task() {
     fix.test("todo new a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(New))
+        .printed_task(&task("a", 1, Incomplete).action(New))
         .end();
 }
 
@@ -26,9 +26,9 @@ fn new_multiple_tasks() {
     fix.test("todo new a b c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete).action(New))
+        .printed_task(&task("a", 1, Incomplete).action(New))
+        .printed_task(&task("b", 2, Incomplete).action(New))
+        .printed_task(&task("c", 3, Incomplete).action(New))
         .end();
 }
 
@@ -40,8 +40,8 @@ fn new_block_on_complete_task() {
     fix.test("todo new b -p 0")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).action(New))
+        .printed_task(&task("a", 0, Complete))
+        .printed_task(&task("b", 1, Incomplete).action(New))
         .end();
 }
 
@@ -53,12 +53,8 @@ fn new_blocking_complete_task() {
     fix.test("todo new b -b 0")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
-                .action(New)
-                .adeps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("b", 1, Incomplete).action(New).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -69,13 +65,9 @@ fn new_by_name() {
     fix.test("todo new d -p c -b a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("c", 2, Incomplete).adeps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("d", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("a", 4, Blocked).deps_stats(1, 2))
+        .printed_task(&task("c", 2, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("d", 3, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("a", 4, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -85,21 +77,9 @@ fn new_chain_three() {
     fix.test("todo new a b c --chain")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(New)
-                .adeps_stats(1, 2),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("a", 1, Incomplete).action(New).adeps_stats(1, 2))
+        .printed_task(&task("b", 2, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).action(New).deps_stats(1, 2))
         .end();
 }
 
@@ -110,12 +90,8 @@ fn new_one_blocking_one() {
     fix.test("todo new b --blocking 1")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
-                .action(New)
-                .adeps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("b", 1, Incomplete).action(New).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -126,12 +102,8 @@ fn new_blocked_by_one() {
     fix.test("todo new b --blocked-by 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("b", 2, Blocked).action(New).deps_stats(1, 1))
         .end();
 }
 
@@ -142,12 +114,8 @@ fn new_one_blocking_one_short() {
     fix.test("todo new b -b 1")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
-                .action(New)
-                .adeps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("b", 1, Incomplete).action(New).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -158,12 +126,8 @@ fn new_blocked_by_one_short() {
     fix.test("todo new b -p 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("b", 2, Blocked).action(New).deps_stats(1, 1))
         .end();
 }
 
@@ -174,14 +138,10 @@ fn new_blocking_multiple() {
     fix.test("todo new d -b 1 2 3")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("d", 1, Incomplete)
-                .action(New)
-                .adeps_stats(3, 3),
-        )
-        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
-        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 1))
-        .printed_task(&PrintableTask::new("c", 4, Blocked).deps_stats(1, 1))
+        .printed_task(&task("d", 1, Incomplete).action(New).adeps_stats(3, 3))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("b", 3, Blocked).deps_stats(1, 1))
+        .printed_task(&task("c", 4, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -192,13 +152,9 @@ fn new_blocking_and_blocked_by() {
     fix.test("todo new c -p 1 -b 2")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("c", 2, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("b", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -209,13 +165,9 @@ fn new_in_between_blocking_pair() {
     fix.test("todo new c -p 1 -b 2")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("c", 2, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("b", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -226,13 +178,9 @@ fn new_one_before_one() {
     fix.test("todo new d --before b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 3))
-        .printed_task(
-            &PrintableTask::new("d", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 3))
+        .printed_task(&task("d", 2, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("b", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -243,23 +191,11 @@ fn new_three_before_one() {
     fix.test("todo new d e f --before b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(3, 5))
-        .printed_task(
-            &PrintableTask::new("d", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("e", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("f", 4, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("b", 5, Blocked).deps_stats(1, 4))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(3, 5))
+        .printed_task(&task("d", 2, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("e", 3, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("f", 4, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("b", 5, Blocked).deps_stats(1, 4))
         .end();
 }
 
@@ -271,15 +207,11 @@ fn new_one_before_three() {
     fix.test("todo new e --before b c d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 4))
-        .printed_task(
-            &PrintableTask::new("e", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 2))
-        .printed_task(&PrintableTask::new("c", 4, Blocked).deps_stats(1, 2))
-        .printed_task(&PrintableTask::new("d", 5, Blocked).deps_stats(1, 2))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 4))
+        .printed_task(&task("e", 2, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("b", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&task("c", 4, Blocked).deps_stats(1, 2))
+        .printed_task(&task("d", 5, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -290,13 +222,9 @@ fn new_one_after_one() {
     fix.test("todo new d --after b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("d", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 2),
-        )
-        .printed_task(&PrintableTask::new("c", 4, Blocked).deps_stats(1, 3))
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("d", 3, Blocked).action(New).deps_stats(1, 2))
+        .printed_task(&task("c", 4, Blocked).deps_stats(1, 3))
         .end();
 }
 
@@ -307,23 +235,11 @@ fn new_three_after_one() {
     fix.test("todo new d e f --after b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("d", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 2),
-        )
-        .printed_task(
-            &PrintableTask::new("e", 4, Blocked)
-                .action(New)
-                .deps_stats(1, 2),
-        )
-        .printed_task(
-            &PrintableTask::new("f", 5, Blocked)
-                .action(New)
-                .deps_stats(1, 2),
-        )
-        .printed_task(&PrintableTask::new("c", 6, Blocked).deps_stats(1, 5))
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("d", 3, Blocked).action(New).deps_stats(1, 2))
+        .printed_task(&task("e", 4, Blocked).action(New).deps_stats(1, 2))
+        .printed_task(&task("f", 5, Blocked).action(New).deps_stats(1, 2))
+        .printed_task(&task("c", 6, Blocked).deps_stats(1, 5))
         .end();
 }
 
@@ -334,15 +250,11 @@ fn new_one_after_three() {
     fix.test("todo new d -p a b c");
     fix.test("todo new e --after a b c")
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 2))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).adeps_stats(0, 2))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete).adeps_stats(0, 2))
-        .printed_task(
-            &PrintableTask::new("e", 4, Blocked)
-                .action(New)
-                .deps_stats(3, 3),
-        )
-        .printed_task(&PrintableTask::new("d", 5, Blocked).deps_stats(3, 4))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(0, 2))
+        .printed_task(&task("b", 2, Incomplete).adeps_stats(0, 2))
+        .printed_task(&task("c", 3, Incomplete).adeps_stats(0, 2))
+        .printed_task(&task("e", 4, Blocked).action(New).deps_stats(3, 3))
+        .printed_task(&task("d", 5, Blocked).deps_stats(3, 4))
         .end();
 }
 
@@ -353,13 +265,9 @@ fn new_one_by_one() {
     fix.test("todo new d --by b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 3))
-        .printed_task(
-            &PrintableTask::new("d", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("c", 4, Blocked).deps_stats(1, 3))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(2, 3))
+        .printed_task(&task("d", 3, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("c", 4, Blocked).deps_stats(1, 3))
         .end();
 }
 
@@ -370,23 +278,11 @@ fn new_three_by_one() {
     fix.test("todo new d e f --by b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(4, 5))
-        .printed_task(
-            &PrintableTask::new("d", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("e", 4, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("f", 5, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("c", 6, Blocked).deps_stats(1, 5))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(4, 5))
+        .printed_task(&task("d", 3, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("e", 4, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("f", 5, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("c", 6, Blocked).deps_stats(1, 5))
         .end();
 }
 
@@ -398,12 +294,8 @@ fn new_one_by_three() {
     fix.test("todo new e --by a b c")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("e", 4, Incomplete)
-                .action(New)
-                .adeps_stats(0, 1),
-        )
-        .printed_task(&PrintableTask::new("d", 5, Blocked).deps_stats(4, 4))
+        .printed_task(&task("e", 4, Incomplete).action(New).adeps_stats(0, 1))
+        .printed_task(&task("d", 5, Blocked).deps_stats(4, 4))
         .end();
 }
 
@@ -414,13 +306,9 @@ fn new_one_by_one_with_chain() {
     fix.test("todo new d --by b --chain")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 3))
-        .printed_task(
-            &PrintableTask::new("d", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("c", 4, Blocked).deps_stats(1, 3))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(2, 3))
+        .printed_task(&task("d", 3, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("c", 4, Blocked).deps_stats(1, 3))
         .end();
 }
 
@@ -431,23 +319,11 @@ fn new_three_by_one_with_chain() {
     fix.test("todo new d e f --by b --chain")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 5))
-        .printed_task(
-            &PrintableTask::new("d", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("e", 4, Blocked)
-                .action(New)
-                .deps_stats(1, 2),
-        )
-        .printed_task(
-            &PrintableTask::new("f", 5, Blocked)
-                .action(New)
-                .deps_stats(1, 3),
-        )
-        .printed_task(&PrintableTask::new("c", 6, Blocked).deps_stats(1, 5))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(2, 5))
+        .printed_task(&task("d", 3, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("e", 4, Blocked).action(New).deps_stats(1, 2))
+        .printed_task(&task("f", 5, Blocked).action(New).deps_stats(1, 3))
+        .printed_task(&task("c", 6, Blocked).deps_stats(1, 5))
         .end();
 }
 
@@ -472,9 +348,7 @@ fn new_with_priority() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(New)
-                .priority(Explicit(1)),
+            &task("a", 1, Incomplete).action(New).priority(Explicit(1)),
         )
         .end();
 }
@@ -487,9 +361,7 @@ fn new_task_with_priority_inserted_before_unprioritized_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("c", 1, Incomplete)
-                .action(New)
-                .priority(Explicit(1)),
+            &task("c", 1, Incomplete).action(New).priority(Explicit(1)),
         )
         .end();
 }
@@ -502,9 +374,7 @@ fn new_task_with_negative_priority_inserted_after_unprioritized_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("c", 3, Incomplete)
-                .action(New)
-                .priority(Explicit(-1)),
+            &task("c", 3, Incomplete).action(New).priority(Explicit(-1)),
         )
         .end();
 }
@@ -518,9 +388,7 @@ fn new_task_with_priority_inserted_in_sorted_order() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("c", 2, Incomplete)
-                .action(New)
-                .priority(Explicit(2)),
+            &task("c", 2, Incomplete).action(New).priority(Explicit(2)),
         )
         .end();
 }
@@ -534,7 +402,7 @@ fn new_with_due_date() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .due_date(Explicit(in_5_hours))
                 .action(New),
         )
@@ -564,22 +432,22 @@ fn new_with_due_date_shows_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .due_date(Implicit(in_2_days))
                 .adeps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
+            &task("b", 2, Blocked)
                 .due_date(Implicit(in_2_days))
                 .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .due_date(Implicit(in_2_days))
                 .deps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("d", 4, Blocked)
+            &task("d", 4, Blocked)
                 .due_date(Explicit(in_2_days))
                 .action(New)
                 .deps_stats(1, 3),
@@ -598,12 +466,12 @@ fn new_with_budget_shows_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .due_date(Implicit(before_7))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
+            &task("b", 2, Blocked)
                 .due_date(Explicit(end_of_day))
                 .budget(Duration::hours(5))
                 .action(New)
@@ -657,7 +525,7 @@ fn new_snooze_one_task() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Blocked)
+            &task("a", 1, Blocked)
                 .action(New)
                 .start_date(ymdhms(2021, 05, 29, 00, 00, 00)),
         )
@@ -672,17 +540,17 @@ fn new_snooze_multiple_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Blocked)
+            &task("a", 1, Blocked)
                 .action(New)
                 .start_date(ymdhms(2021, 05, 30, 00, 00, 00)),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
+            &task("b", 2, Blocked)
                 .action(New)
                 .start_date(ymdhms(2021, 05, 30, 00, 00, 00)),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .action(New)
                 .start_date(ymdhms(2021, 05, 30, 00, 00, 00)),
         )
@@ -695,7 +563,7 @@ fn new_complete_task() {
     fix.test("todo new a --done")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).action(New))
+        .printed_task(&task("a", 0, Complete).action(New))
         .end();
 }
 
@@ -705,9 +573,9 @@ fn multiple_new_complete_tasks() {
     fix.test("todo new a b c --done")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -2, Complete).action(New))
-        .printed_task(&PrintableTask::new("b", -1, Complete).action(New))
-        .printed_task(&PrintableTask::new("c", 0, Complete).action(New))
+        .printed_task(&task("a", -2, Complete).action(New))
+        .printed_task(&task("b", -1, Complete).action(New))
+        .printed_task(&task("c", 0, Complete).action(New))
         .end();
 }
 
@@ -717,9 +585,9 @@ fn new_complete_chain() {
     fix.test("todo new a b c --chain --done")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -2, Complete).action(New))
-        .printed_task(&PrintableTask::new("b", -1, Complete).action(New))
-        .printed_task(&PrintableTask::new("c", 0, Complete).action(New))
+        .printed_task(&task("a", -2, Complete).action(New))
+        .printed_task(&task("b", -1, Complete).action(New))
+        .printed_task(&task("c", 0, Complete).action(New))
         .end();
 }
 
@@ -777,12 +645,8 @@ fn new_block_completed_task() {
     fix.test("todo new b -b a")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
-                .action(New)
-                .adeps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("b", 1, Incomplete).action(New).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -793,13 +657,9 @@ fn new_transitively_block_completed_task() {
     fix.test("todo new a -b b")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(New)
-                .adeps_stats(1, 2),
-        )
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(&PrintableTask::new("c", 3, Blocked).deps_stats(1, 2))
+        .printed_task(&task("a", 1, Incomplete).action(New).adeps_stats(1, 2))
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -809,9 +669,7 @@ fn new_as_tag() {
     fix.test("todo new a --tag")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).action(New).as_tag(),
-        )
+        .printed_task(&task("a", 1, Incomplete).action(New).as_tag())
         .end();
 }
 
@@ -821,15 +679,9 @@ fn new_multiple_as_tag() {
     fix.test("todo new a b c --tag")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).action(New).as_tag(),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 2, Incomplete).action(New).as_tag(),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 3, Incomplete).action(New).as_tag(),
-        )
+        .printed_task(&task("a", 1, Incomplete).action(New).as_tag())
+        .printed_task(&task("b", 2, Incomplete).action(New).as_tag())
+        .printed_task(&task("c", 3, Incomplete).action(New).as_tag())
         .end();
 }
 
@@ -841,16 +693,12 @@ fn new_blocking_tag() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .action(New)
                 .tag("a")
                 .adeps_stats(1, 1),
         )
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .as_tag()
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("a", 2, Blocked).as_tag().deps_stats(1, 1))
         .end();
 }
 
@@ -862,17 +710,13 @@ fn new_tag_blocking_tag() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .action(New)
                 .tag("a")
                 .as_tag()
                 .adeps_stats(1, 1),
         )
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .as_tag()
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("a", 2, Blocked).as_tag().deps_stats(1, 1))
         .end();
 }
 
@@ -883,7 +727,7 @@ fn new_tag_chain() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .action(New)
                 .tag("c")
                 .tag("b")
@@ -891,17 +735,14 @@ fn new_tag_chain() {
                 .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
+            &task("b", 2, Blocked)
                 .action(New)
                 .tag("c")
                 .as_tag()
                 .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .action(New)
-                .as_tag()
-                .deps_stats(1, 2),
+            &task("c", 3, Blocked).action(New).as_tag().deps_stats(1, 2),
         )
         .end();
 }
@@ -912,17 +753,17 @@ fn trim_leading_whitespace_from_desc() {
     fix.test("todo new a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(New))
+        .printed_task(&task("a", 1, Incomplete).action(New))
         .end();
     fix.test("todo new ' a'")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 2, Incomplete).action(New))
+        .printed_task(&task("a", 2, Incomplete).action(New))
         .end();
     fix.test("todo new '  a'")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 3, Incomplete).action(New))
+        .printed_task(&task("a", 3, Incomplete).action(New))
         .end();
 }
 
@@ -932,16 +773,16 @@ fn trim_trailing_whitespace_from_desc() {
     fix.test("todo new a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(New))
+        .printed_task(&task("a", 1, Incomplete).action(New))
         .end();
     fix.test("todo new 'a '")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 2, Incomplete).action(New))
+        .printed_task(&task("a", 2, Incomplete).action(New))
         .end();
     fix.test("todo new 'a  '")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 3, Incomplete).action(New))
+        .printed_task(&task("a", 3, Incomplete).action(New))
         .end();
 }

--- a/app/src/path_test.rs
+++ b/app/src/path_test.rs
@@ -1,10 +1,8 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
     lookup_key::Key,
-    printing::{
-        Action::*, BriefPrintableTask, PrintableTask, PrintableWarning,
-        Status::*,
-    },
+    printing::{Action::*, BriefPrintableTask, PrintableWarning, Status::*},
 };
 
 #[test]
@@ -29,15 +27,9 @@ fn path_between_tasks_with_direct_dependency() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .adeps_stats(1, 1),
+            &task("a", 1, Incomplete).action(Select).adeps_stats(1, 1),
         )
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
         .end();
 }
 
@@ -49,16 +41,10 @@ fn path_between_tasks_with_indirect_dependency() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .adeps_stats(1, 2),
+            &task("a", 1, Incomplete).action(Select).adeps_stats(1, 2),
         )
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .action(Select)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).action(Select).deps_stats(1, 2))
         .end();
 }
 
@@ -112,7 +98,7 @@ fn path_between_task_with_one_match() {
     fix.test("todo path a")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
+        .printed_task(&task("a", 1, Incomplete).action(Select))
         .end();
 }
 
@@ -131,16 +117,10 @@ fn path_between_tasks_of_same_name() {
             ],
         })
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .adeps_stats(1, 2),
+            &task("a", 1, Incomplete).action(Select).adeps_stats(1, 2),
         )
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("a", 3, Blocked)
-                .action(Select)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("a", 3, Blocked).action(Select).deps_stats(1, 2))
         .end();
 }
 
@@ -152,21 +132,11 @@ fn path_between_three_tasks() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .adeps_stats(1, 4),
+            &task("a", 1, Incomplete).action(Select).adeps_stats(1, 4),
         )
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .action(Select)
-                .deps_stats(1, 2),
-        )
-        .printed_task(&PrintableTask::new("d", 4, Blocked).deps_stats(1, 3))
-        .printed_task(
-            &PrintableTask::new("e", 5, Blocked)
-                .action(Select)
-                .deps_stats(1, 4),
-        )
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).action(Select).deps_stats(1, 2))
+        .printed_task(&task("d", 4, Blocked).deps_stats(1, 3))
+        .printed_task(&task("e", 5, Blocked).action(Select).deps_stats(1, 4))
         .end();
 }

--- a/app/src/priority_test.rs
+++ b/app/src/priority_test.rs
@@ -1,6 +1,7 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{Plicit::*, PrintableTask, Status::*},
+    printing::{Plicit::*, Status::*},
 };
 
 #[test]
@@ -10,9 +11,7 @@ fn priority_set_for_one_task() {
     fix.test("todo priority a --is 1")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).priority(Explicit(1)),
-        )
+        .printed_task(&task("a", 1, Incomplete).priority(Explicit(1)))
         .end();
 }
 
@@ -23,15 +22,9 @@ fn priority_set_for_three_tasks() {
     fix.test("todo priority a b c --is 2")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete).priority(Explicit(2)),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 2, Incomplete).priority(Explicit(2)),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 3, Incomplete).priority(Explicit(2)),
-        )
+        .printed_task(&task("a", 1, Incomplete).priority(Explicit(2)))
+        .printed_task(&task("b", 2, Incomplete).priority(Explicit(2)))
+        .printed_task(&task("c", 3, Incomplete).priority(Explicit(2)))
         .end();
 }
 
@@ -42,18 +35,14 @@ fn priority_reorders_task() {
     fix.test("todo priority b --is 1")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("b", 1, Incomplete).priority(Explicit(1)),
-        )
+        .printed_task(&task("b", 1, Incomplete).priority(Explicit(1)))
         .end();
     fix.test("todo")
         .modified(false)
         .validate()
-        .printed_task(
-            &PrintableTask::new("b", 1, Incomplete).priority(Explicit(1)),
-        )
-        .printed_task(&PrintableTask::new("a", 2, Incomplete))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete))
+        .printed_task(&task("b", 1, Incomplete).priority(Explicit(1)))
+        .printed_task(&task("a", 2, Incomplete))
+        .printed_task(&task("c", 3, Incomplete))
         .end();
 }
 
@@ -66,19 +55,17 @@ fn priority_shows_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 2, Incomplete)
+            &task("c", 2, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("d", 4, Blocked)
-                .priority(Explicit(1))
-                .deps_stats(2, 2),
+            &task("d", 4, Blocked).priority(Explicit(1)).deps_stats(2, 2),
         )
         .end();
 }
@@ -93,14 +80,12 @@ fn priority_does_not_show_complete_affected_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("c", 1, Incomplete)
+            &task("c", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("d", 3, Blocked)
-                .priority(Explicit(1))
-                .deps_stats(1, 2),
+            &task("d", 3, Blocked).priority(Explicit(1)).deps_stats(1, 2),
         )
         .end();
 }
@@ -114,18 +99,14 @@ fn priority_include_done() {
     fix.test("todo priority d --is 1 --include-done")
         .modified(true)
         .validate()
+        .printed_task(&task("a", 0, Complete).priority(Implicit(1)))
         .printed_task(
-            &PrintableTask::new("a", 0, Complete).priority(Implicit(1)),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 1, Incomplete)
+            &task("c", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("d", 3, Blocked)
-                .priority(Explicit(1))
-                .deps_stats(1, 2),
+            &task("d", 3, Blocked).priority(Explicit(1)).deps_stats(1, 2),
         )
         .end();
 }
@@ -138,19 +119,15 @@ fn priority_shows_affected_transitive_deps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 1),
+            &task("b", 2, Blocked).priority(Implicit(1)).deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .priority(Explicit(1))
-                .deps_stats(1, 2),
+            &task("c", 3, Blocked).priority(Explicit(1)).deps_stats(1, 2),
         )
         .end();
 }
@@ -162,9 +139,7 @@ fn priority_set_negative() {
     fix.test("todo priority a --is -1")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 3, Incomplete).priority(Explicit(-1)),
-        )
+        .printed_task(&task("a", 3, Incomplete).priority(Explicit(-1)))
         .end();
 }
 
@@ -178,24 +153,22 @@ fn priority_does_not_show_deps_with_higher_priorities() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("d", 4, Incomplete)
+            &task("d", 4, Incomplete)
                 .priority(Implicit(2))
                 .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("e", 5, Incomplete)
+            &task("e", 5, Incomplete)
                 .priority(Implicit(2))
                 .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("f", 6, Incomplete)
+            &task("f", 6, Incomplete)
                 .priority(Implicit(2))
                 .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("g", 7, Blocked)
-                .priority(Explicit(2))
-                .deps_stats(6, 6),
+            &task("g", 7, Blocked).priority(Explicit(2)).deps_stats(6, 6),
         )
         .end();
 }
@@ -209,15 +182,9 @@ fn get_all_tasks_with_priority() {
     fix.test("todo priority --is 2")
         .modified(false)
         .validate()
-        .printed_task(
-            &PrintableTask::new("g", 1, Incomplete).priority(Explicit(2)),
-        )
-        .printed_task(
-            &PrintableTask::new("h", 2, Incomplete).priority(Explicit(2)),
-        )
-        .printed_task(
-            &PrintableTask::new("i", 3, Incomplete).priority(Explicit(2)),
-        )
+        .printed_task(&task("g", 1, Incomplete).priority(Explicit(2)))
+        .printed_task(&task("h", 2, Incomplete).priority(Explicit(2)))
+        .printed_task(&task("i", 3, Incomplete).priority(Explicit(2)))
         .end();
 }
 
@@ -230,24 +197,12 @@ fn get_all_tasks_with_unspecified_priority() {
     fix.test("todo priority --is 1")
         .modified(false)
         .validate()
-        .printed_task(
-            &PrintableTask::new("g", 1, Incomplete).priority(Explicit(2)),
-        )
-        .printed_task(
-            &PrintableTask::new("h", 2, Incomplete).priority(Explicit(2)),
-        )
-        .printed_task(
-            &PrintableTask::new("i", 3, Incomplete).priority(Explicit(2)),
-        )
-        .printed_task(
-            &PrintableTask::new("d", 4, Incomplete).priority(Explicit(1)),
-        )
-        .printed_task(
-            &PrintableTask::new("e", 5, Incomplete).priority(Explicit(1)),
-        )
-        .printed_task(
-            &PrintableTask::new("f", 6, Incomplete).priority(Explicit(1)),
-        )
+        .printed_task(&task("g", 1, Incomplete).priority(Explicit(2)))
+        .printed_task(&task("h", 2, Incomplete).priority(Explicit(2)))
+        .printed_task(&task("i", 3, Incomplete).priority(Explicit(2)))
+        .printed_task(&task("d", 4, Incomplete).priority(Explicit(1)))
+        .printed_task(&task("e", 5, Incomplete).priority(Explicit(1)))
+        .printed_task(&task("f", 6, Incomplete).priority(Explicit(1)))
         .end();
 }
 
@@ -260,19 +215,15 @@ fn explain_source_of_priority() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 1),
+            &task("b", 2, Blocked).priority(Implicit(1)).deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .priority(Explicit(1))
-                .deps_stats(1, 2),
+            &task("c", 3, Blocked).priority(Explicit(1)).deps_stats(1, 2),
         )
         .end();
 }
@@ -286,39 +237,27 @@ fn explain_source_of_priority_deep() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 8),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 1),
+            &task("b", 2, Blocked).priority(Implicit(1)).deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 2),
+            &task("c", 3, Blocked).priority(Implicit(1)).deps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("d", 4, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 3),
+            &task("d", 4, Blocked).priority(Implicit(1)).deps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("e", 5, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 4),
+            &task("e", 5, Blocked).priority(Implicit(1)).deps_stats(1, 4),
         )
         .printed_task(
-            &PrintableTask::new("f", 6, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 5),
+            &task("f", 6, Blocked).priority(Implicit(1)).deps_stats(1, 5),
         )
         .printed_task(
-            &PrintableTask::new("g", 7, Blocked)
-                .priority(Explicit(1))
-                .deps_stats(1, 6),
+            &task("g", 7, Blocked).priority(Explicit(1)).deps_stats(1, 6),
         )
         .end();
 }

--- a/app/src/punt_test.rs
+++ b/app/src/punt_test.rs
@@ -1,6 +1,7 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, PrintableTask, Status::*},
+    printing::{Action::*, Status::*},
 };
 
 #[test]
@@ -10,7 +11,7 @@ fn punt_first_task() {
     fix.test("todo punt 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 3, Incomplete).action(Punt))
+        .printed_task(&task("a", 3, Incomplete).action(Punt))
         .end();
 }
 
@@ -24,11 +25,7 @@ fn punt_blocked_task() {
         // need to mark the session as modified.
         // .modified(false)
         .validate()
-        .printed_task(
-            &PrintableTask::new("b", 3, Blocked)
-                .action(Punt)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("b", 3, Blocked).action(Punt).deps_stats(1, 1))
         .end();
 }
 
@@ -39,6 +36,6 @@ fn punt_by_name() {
     fix.test("todo punt a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 3, Incomplete).action(Punt))
+        .printed_task(&task("a", 3, Incomplete).action(Punt))
         .end();
 }

--- a/app/src/put_test.rs
+++ b/app/src/put_test.rs
@@ -1,8 +1,8 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
     printing::{
-        Action::*, BriefPrintableTask, Plicit::*, PrintableError,
-        PrintableTask, Status::*,
+        Action::*, BriefPrintableTask, Plicit::*, PrintableError, Status::*,
     },
 };
 
@@ -13,12 +13,8 @@ fn put_one_after_one() {
     fix.test("todo put a --after b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).action(Lock).deps_stats(1, 1))
         .end();
 }
 
@@ -29,22 +25,10 @@ fn put_three_after_one() {
     fix.test("todo put a b c --after d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", 1, Incomplete).adeps_stats(3, 3))
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 3, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("d", 1, Incomplete).adeps_stats(3, 3))
+        .printed_task(&task("a", 2, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("b", 3, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("c", 4, Blocked).action(Lock).deps_stats(1, 1))
         .end();
 }
 
@@ -55,14 +39,10 @@ fn put_one_after_three() {
     fix.test("todo put a --after b c d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("d", 3, Incomplete).adeps_stats(0, 1))
-        .printed_task(
-            &PrintableTask::new("a", 4, Blocked)
-                .action(Lock)
-                .deps_stats(3, 3),
-        )
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("c", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("d", 3, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("a", 4, Blocked).action(Lock).deps_stats(3, 3))
         .end();
 }
 
@@ -74,17 +54,9 @@ fn put_after_task_with_adeps() {
     fix.test("todo put c --after a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 3, Blocked)
-                .action(Lock)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("c", 2, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("b", 3, Blocked).action(Lock).deps_stats(1, 2))
         .end();
 }
 
@@ -95,12 +67,8 @@ fn put_one_before_one() {
     fix.test("todo put b --before a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).action(Lock).deps_stats(1, 1))
         .end();
 }
 
@@ -111,14 +79,10 @@ fn put_three_before_one() {
     fix.test("todo put b c d --before a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("d", 3, Incomplete).adeps_stats(0, 1))
-        .printed_task(
-            &PrintableTask::new("a", 4, Blocked)
-                .action(Lock)
-                .deps_stats(3, 3),
-        )
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("c", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("d", 3, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("a", 4, Blocked).action(Lock).deps_stats(3, 3))
         .end();
 }
 
@@ -129,22 +93,10 @@ fn put_one_before_three() {
     fix.test("todo put d --before a b c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("d", 1, Incomplete).adeps_stats(3, 3))
-        .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 3, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("d", 1, Incomplete).adeps_stats(3, 3))
+        .printed_task(&task("a", 2, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("b", 3, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("c", 4, Blocked).action(Lock).deps_stats(1, 1))
         .end();
 }
 
@@ -156,17 +108,9 @@ fn put_before_task_with_deps() {
     fix.test("todo put c --before b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 3, Blocked)
-                .action(Lock)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
+        .printed_task(&task("c", 2, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("b", 3, Blocked).action(Lock).deps_stats(1, 2))
         .end();
 }
 
@@ -179,23 +123,11 @@ fn put_before_and_after() {
     fix.test("todo put g -B b -A e")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 4))
-        .printed_task(&PrintableTask::new("e", 3, Blocked).deps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("g", 4, Blocked)
-                .action(Lock)
-                .deps_stats(2, 3),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 5, Blocked)
-                .action(Lock)
-                .deps_stats(2, 4),
-        )
-        .printed_task(
-            &PrintableTask::new("f", 6, Blocked)
-                .action(Lock)
-                .deps_stats(2, 4),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(0, 4))
+        .printed_task(&task("e", 3, Blocked).deps_stats(1, 1))
+        .printed_task(&task("g", 4, Blocked).action(Lock).deps_stats(2, 3))
+        .printed_task(&task("b", 5, Blocked).action(Lock).deps_stats(2, 4))
+        .printed_task(&task("f", 6, Blocked).action(Lock).deps_stats(2, 4))
         .end();
 }
 
@@ -214,8 +146,8 @@ fn put_causing_cycle() {
     fix.test("todo -a")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -228,26 +160,20 @@ fn put_before_prints_updated_priority() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 1),
+            &task("b", 2, Blocked).priority(Implicit(1)).deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .priority(Explicit(1))
                 .action(Lock)
                 .deps_stats(1, 2),
         )
-        .printed_task(
-            &PrintableTask::new("d", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("d", 4, Blocked).action(Lock).deps_stats(1, 3))
         .end();
 }
 
@@ -260,26 +186,20 @@ fn put_after_prints_updated_priority() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .priority(Implicit(1))
-                .deps_stats(1, 1),
+            &task("b", 2, Blocked).priority(Implicit(1)).deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .priority(Explicit(1))
                 .action(Lock)
                 .deps_stats(1, 2),
         )
-        .printed_task(
-            &PrintableTask::new("d", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("d", 4, Blocked).action(Lock).deps_stats(1, 3))
         .end();
 }
 
@@ -293,12 +213,12 @@ fn put_excludes_complete_affected_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
+            &task("c", 2, Blocked)
                 .priority(Explicit(1))
                 .action(Lock)
                 .deps_stats(1, 2),
@@ -315,16 +235,14 @@ fn put_include_done() {
     fix.test("todo put c --after b -d")
         .modified(true)
         .validate()
+        .printed_task(&task("a", 0, Complete).priority(Implicit(1)))
         .printed_task(
-            &PrintableTask::new("a", 0, Complete).priority(Implicit(1)),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
+            &task("b", 1, Incomplete)
                 .priority(Implicit(1))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
+            &task("c", 2, Blocked)
                 .priority(Explicit(1))
                 .action(Lock)
                 .deps_stats(1, 2),
@@ -340,12 +258,8 @@ fn put_task_by_initial_task() {
     fix.test("todo put t --by a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("t", 2, Incomplete).adeps_stats(0, 2))
-        .printed_task(
-            &PrintableTask::new("b", 3, Blocked)
-                .action(Lock)
-                .deps_stats(2, 2),
-        )
+        .printed_task(&task("t", 2, Incomplete).adeps_stats(0, 2))
+        .printed_task(&task("b", 3, Blocked).action(Lock).deps_stats(2, 2))
         .end();
 }
 
@@ -357,17 +271,9 @@ fn put_task_by_interior_task() {
     fix.test("todo put t --by b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 3))
-        .printed_task(
-            &PrintableTask::new("t", 3, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(2, 3))
+        .printed_task(&task("t", 3, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("c", 4, Blocked).action(Lock).deps_stats(1, 3))
         .end();
 }
 
@@ -379,12 +285,8 @@ fn put_task_by_terminal_task() {
     fix.test("todo put t --by c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("t", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("t", 4, Blocked).action(Lock).deps_stats(1, 2))
         .end();
 }
 
@@ -408,16 +310,8 @@ fn put_task_by_complete_task() {
     fix.test("todo put t --by b")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("t", 1, Incomplete)
-                .action(Lock)
-                .adeps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("t", 1, Incomplete).action(Lock).adeps_stats(1, 1))
+        .printed_task(&task("c", 2, Blocked).action(Lock).deps_stats(1, 3))
         .end();
 }
 
@@ -430,17 +324,9 @@ fn put_task_by_complete_task_include_done() {
     fix.test("todo put t --by b -d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -1, Complete))
-        .printed_task(
-            &PrintableTask::new("t", 1, Incomplete)
-                .action(Lock)
-                .adeps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("a", -1, Complete))
+        .printed_task(&task("t", 1, Incomplete).action(Lock).adeps_stats(1, 1))
+        .printed_task(&task("c", 2, Blocked).action(Lock).deps_stats(1, 3))
         .end();
 }
 
@@ -453,17 +339,9 @@ fn put_task_by_task_whose_adeps_are_complete() {
     fix.test("todo put t --by b -d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -1, Complete))
-        .printed_task(
-            &PrintableTask::new("t", 1, Incomplete)
-                .action(Lock)
-                .adeps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("a", -1, Complete))
+        .printed_task(&task("t", 1, Incomplete).action(Lock).adeps_stats(1, 1))
+        .printed_task(&task("c", 2, Blocked).action(Lock).deps_stats(1, 3))
         .end();
 }
 
@@ -475,16 +353,8 @@ fn put_complete_task_by_task() {
     fix.test("todo put t --by b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 3))
-        .printed_task(
-            &PrintableTask::new("t", 3, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(2, 3))
+        .printed_task(&task("t", 3, Blocked).action(Lock).deps_stats(1, 1))
+        .printed_task(&task("c", 4, Blocked).action(Lock).deps_stats(1, 3))
         .end();
 }

--- a/app/src/restore_test.rs
+++ b/app/src/restore_test.rs
@@ -1,8 +1,9 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
     printing::{
-        Action::*, BriefPrintableTask, PrintableError, PrintableTask,
-        PrintableWarning, Status::*,
+        Action::*, BriefPrintableTask, PrintableError, PrintableWarning,
+        Status::*,
     },
 };
 
@@ -29,7 +30,7 @@ fn restore_complete_task() {
     fix.test("todo restore 0")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
+        .printed_task(&task("a", 1, Incomplete).action(Uncheck))
         .end();
 }
 
@@ -42,7 +43,7 @@ fn restore_task_with_negative_number() {
     fix.test("todo restore -1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 2, Incomplete).action(Uncheck))
+        .printed_task(&task("a", 2, Incomplete).action(Uncheck))
         .end();
 }
 
@@ -54,7 +55,7 @@ fn restore_same_task_with_multiple_keys() {
     fix.test("todo restore 0 0")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 2, Incomplete).action(Uncheck))
+        .printed_task(&task("a", 2, Incomplete).action(Uncheck))
         .end();
 }
 
@@ -68,15 +69,9 @@ fn restore_task_with_incomplete_antidependency() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Uncheck)
-                .adeps_stats(1, 1),
+            &task("a", 1, Incomplete).action(Uncheck).adeps_stats(1, 1),
         )
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Lock)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("b", 2, Blocked).action(Lock).deps_stats(1, 1))
         .end();
 }
 
@@ -109,7 +104,7 @@ fn restore_by_name() {
     fix.test("todo restore a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 2, Incomplete).action(Uncheck))
+        .printed_task(&task("a", 2, Incomplete).action(Uncheck))
         .end();
 }
 
@@ -121,7 +116,7 @@ fn force_restore_complete_task() {
     fix.test("todo restore a --force")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Uncheck))
+        .printed_task(&task("a", 1, Incomplete).action(Uncheck))
         .end();
 }
 
@@ -149,15 +144,9 @@ fn force_restore_task_with_complete_adeps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Uncheck)
-                .adeps_stats(1, 1),
+            &task("a", 1, Incomplete).action(Uncheck).adeps_stats(1, 1),
         )
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Uncheck)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("b", 2, Blocked).action(Uncheck).deps_stats(1, 1))
         .end();
 }
 
@@ -170,20 +159,10 @@ fn force_restore_task_with_complete_adeps_with_complete_adeps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Uncheck)
-                .adeps_stats(1, 2),
+            &task("a", 1, Incomplete).action(Uncheck).adeps_stats(1, 2),
         )
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Uncheck)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .action(Uncheck)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("b", 2, Blocked).action(Uncheck).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).action(Uncheck).deps_stats(1, 2))
         .end();
 }
 
@@ -196,25 +175,11 @@ fn force_restore_task_with_complete_and_incomplete_adeps() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Uncheck)
-                .adeps_stats(1, 3),
+            &task("a", 1, Incomplete).action(Uncheck).adeps_stats(1, 3),
         )
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Uncheck)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .action(Uncheck)
-                .deps_stats(1, 2),
-        )
-        .printed_task(
-            &PrintableTask::new("d", 4, Blocked)
-                .action(Lock)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("b", 2, Blocked).action(Uncheck).deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).action(Uncheck).deps_stats(1, 2))
+        .printed_task(&task("d", 4, Blocked).action(Lock).deps_stats(1, 3))
         .end();
 }
 
@@ -227,14 +192,8 @@ fn restore_chain() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Uncheck)
-                .adeps_stats(1, 1),
+            &task("a", 1, Incomplete).action(Uncheck).adeps_stats(1, 1),
         )
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .action(Uncheck)
-                .deps_stats(1, 1),
-        )
+        .printed_task(&task("b", 2, Blocked).action(Uncheck).deps_stats(1, 1))
         .end();
 }

--- a/app/src/rm_test.rs
+++ b/app/src/rm_test.rs
@@ -1,6 +1,7 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{PrintableInfo, PrintableTask, Status::*},
+    printing::{PrintableInfo, Status::*},
 };
 
 fn info_removed(desc: &str) -> PrintableInfo {
@@ -34,7 +35,7 @@ fn rm_task_with_adeps() {
         .modified(true)
         .validate()
         .printed_info(&info_removed("a"))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&task("b", 1, Incomplete))
         .end();
 }
 
@@ -46,7 +47,7 @@ fn rm_task_with_deps_and_adeps() {
         .modified(true)
         .validate()
         .printed_info(&info_removed("b"))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("c", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -64,8 +65,8 @@ fn rm_three_tasks() {
     fix.test("todo")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("d", 2, Incomplete))
+        .printed_task(&task("b", 1, Incomplete))
+        .printed_task(&task("d", 2, Incomplete))
         .end();
 }
 

--- a/app/src/snooze_test.rs
+++ b/app/src/snooze_test.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::zero_prefixed_literal)]
 
 use {
+    super::testing::task,
     super::testing::Fixture,
     printing::{
         Action::*, BriefPrintableTask, Plicit::Explicit, PrintableError,
-        PrintableTask, PrintableWarning, Status::*,
+        PrintableWarning, Status::*,
     },
     testing::ymdhms,
 };
@@ -31,7 +32,7 @@ fn snooze_one_task() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 2, Blocked)
+            &task("a", 2, Blocked)
                 .start_date(ymdhms(2021, 05, 28, 00, 00, 00))
                 .action(Snooze),
         )
@@ -47,17 +48,17 @@ fn snooze_multiple_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 3, Blocked)
+            &task("a", 3, Blocked)
                 .start_date(ymdhms(2021, 05, 29, 00, 00, 00))
                 .action(Snooze),
         )
         .printed_task(
-            &PrintableTask::new("c", 4, Blocked)
+            &task("c", 4, Blocked)
                 .start_date(ymdhms(2021, 05, 29, 00, 00, 00))
                 .action(Snooze),
         )
         .printed_task(
-            &PrintableTask::new("e", 5, Blocked)
+            &task("e", 5, Blocked)
                 .start_date(ymdhms(2021, 05, 29, 00, 00, 00))
                 .action(Snooze),
         )
@@ -73,7 +74,7 @@ fn snooze_snoozed_task() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Blocked)
+            &task("a", 1, Blocked)
                 .start_date(ymdhms(2021, 05, 27, 14, 00, 00))
                 .action(Snooze),
         )
@@ -104,7 +105,7 @@ fn snooze_blocked_task_above_layer_1() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .start_date(ymdhms(2021, 05, 28, 00, 00, 00))
                 .action(Snooze)
                 .deps_stats(1, 2),
@@ -126,7 +127,7 @@ fn snooze_after_due_date() {
             snooze_date: ymdhms(2022, 10, 04, 00, 00, 00),
         })
         .printed_task(
-            &PrintableTask::new("a", 1, Blocked)
+            &task("a", 1, Blocked)
                 .start_date(ymdhms(2022, 10, 04, 00, 00, 00))
                 .due_date(Explicit(ymdhms(2022, 10, 03, 23, 59, 59)))
                 .action(Snooze),

--- a/app/src/snoozed_test.rs
+++ b/app/src/snoozed_test.rs
@@ -1,6 +1,6 @@
+#[allow(clippy::zero_prefixed_literal)]
 use {
-    super::testing::Fixture,
-    printing::{PrintableTask, Status::*},
+    super::testing::task, super::testing::Fixture, printing::Status::*,
     testing::ymdhms,
 };
 
@@ -20,8 +20,7 @@ fn one_snoozed_task() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("b", 3, Blocked)
-                .start_date(ymdhms(2021, 05, 27, 12, 00, 00)),
+            &task("b", 3, Blocked).start_date(ymdhms(2021, 05, 27, 12, 00, 00)),
         )
         .end();
 }
@@ -36,16 +35,13 @@ fn multiple_snoozed_tasks() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 3, Blocked)
-                .start_date(ymdhms(2022, 10, 15, 13, 00, 00)),
+            &task("a", 3, Blocked).start_date(ymdhms(2022, 10, 15, 13, 00, 00)),
         )
         .printed_task(
-            &PrintableTask::new("b", 4, Blocked)
-                .start_date(ymdhms(2022, 10, 15, 13, 00, 00)),
+            &task("b", 4, Blocked).start_date(ymdhms(2022, 10, 15, 13, 00, 00)),
         )
         .printed_task(
-            &PrintableTask::new("c", 5, Blocked)
-                .start_date(ymdhms(2022, 10, 15, 13, 00, 00)),
+            &task("c", 5, Blocked).start_date(ymdhms(2022, 10, 15, 13, 00, 00)),
         )
         .end();
 }

--- a/app/src/split_test.rs
+++ b/app/src/split_test.rs
@@ -3,8 +3,9 @@
 use chrono::Duration;
 
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, PrintableTask, Status::*},
+    printing::{Action::*, Status::*},
     testing::ymdhms,
 };
 
@@ -15,9 +16,9 @@ fn split_one_into_three() {
     fix.test("todo split a --into a1 a2 a3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a1", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a2", 2, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("a3", 3, Incomplete).action(New))
+        .printed_task(&task("a1", 1, Incomplete).action(New))
+        .printed_task(&task("a2", 2, Incomplete).action(New))
+        .printed_task(&task("a3", 3, Incomplete).action(New))
         .end();
 }
 
@@ -28,21 +29,9 @@ fn split_chained() {
     fix.test("todo split a --into a1 a2 a3 --chain")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a1", 1, Incomplete)
-                .action(New)
-                .adeps_stats(1, 2),
-        )
-        .printed_task(
-            &PrintableTask::new("a2", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("a3", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("a1", 1, Incomplete).action(New).adeps_stats(1, 2))
+        .printed_task(&task("a2", 2, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("a3", 3, Blocked).action(New).deps_stats(1, 2))
         .end();
 }
 
@@ -53,23 +42,11 @@ fn split_preserves_dependency_structure() {
     fix.test("todo split b --into b1 b2 b3")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(3, 4))
-        .printed_task(
-            &PrintableTask::new("b1", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("b2", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("b3", 4, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(&PrintableTask::new("c", 5, Blocked).deps_stats(1, 4))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(3, 4))
+        .printed_task(&task("b1", 2, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("b2", 3, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("b3", 4, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("c", 5, Blocked).deps_stats(1, 4))
         .end();
 }
 
@@ -82,12 +59,12 @@ fn split_snoozed_task() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("x", 1, Blocked)
+            &task("x", 1, Blocked)
                 .action(New)
                 .start_date(ymdhms(2021, 05, 31, 00, 00, 00)),
         )
         .printed_task(
-            &PrintableTask::new("y", 2, Blocked)
+            &task("y", 2, Blocked)
                 .action(New)
                 .start_date(ymdhms(2021, 05, 31, 00, 00, 00)),
         )
@@ -102,19 +79,19 @@ fn chained_split_task_with_budget_distributes_budget() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("x", 1, Incomplete)
+            &task("x", 1, Incomplete)
                 .action(New)
                 .budget(Duration::hours(1))
                 .adeps_stats(1, 2),
         )
         .printed_task(
-            &PrintableTask::new("y", 2, Blocked)
+            &task("y", 2, Blocked)
                 .action(New)
                 .budget(Duration::hours(1))
                 .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("z", 3, Blocked)
+            &task("z", 3, Blocked)
                 .action(New)
                 .budget(Duration::hours(1))
                 .deps_stats(1, 2),
@@ -130,17 +107,17 @@ fn split_task_with_budget_keeps_budget() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("x", 1, Incomplete)
+            &task("x", 1, Incomplete)
                 .action(New)
                 .budget(Duration::hours(3)),
         )
         .printed_task(
-            &PrintableTask::new("y", 2, Incomplete)
+            &task("y", 2, Incomplete)
                 .action(New)
                 .budget(Duration::hours(3)),
         )
         .printed_task(
-            &PrintableTask::new("z", 3, Incomplete)
+            &task("z", 3, Incomplete)
                 .action(New)
                 .budget(Duration::hours(3)),
         )
@@ -154,26 +131,10 @@ fn split_task_keep() {
     fix.test("todo split a --into x y z --keep")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("x", 1, Incomplete)
-                .action(New)
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("y", 2, Incomplete)
-                .action(New)
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("z", 3, Incomplete)
-                .action(New)
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("a", 4, Blocked)
-                .action(Select)
-                .deps_stats(3, 3),
-        )
+        .printed_task(&task("x", 1, Incomplete).action(New).adeps_stats(0, 1))
+        .printed_task(&task("y", 2, Incomplete).action(New).adeps_stats(0, 1))
+        .printed_task(&task("z", 3, Incomplete).action(New).adeps_stats(0, 1))
+        .printed_task(&task("a", 4, Blocked).action(Select).deps_stats(3, 3))
         .end();
 }
 
@@ -184,26 +145,10 @@ fn split_task_keep_chained() {
     fix.test("todo split a --into x y z --keep --chain")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("x", 1, Incomplete)
-                .action(New)
-                .adeps_stats(1, 3),
-        )
-        .printed_task(
-            &PrintableTask::new("y", 2, Blocked)
-                .action(New)
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("z", 3, Blocked)
-                .action(New)
-                .deps_stats(1, 2),
-        )
-        .printed_task(
-            &PrintableTask::new("a", 4, Blocked)
-                .action(Select)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("x", 1, Incomplete).action(New).adeps_stats(1, 3))
+        .printed_task(&task("y", 2, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("z", 3, Blocked).action(New).deps_stats(1, 2))
+        .printed_task(&task("a", 4, Blocked).action(Select).deps_stats(1, 3))
         .end();
 }
 
@@ -215,28 +160,24 @@ fn split_task_keep_with_budget() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("x", 1, Incomplete)
+            &task("x", 1, Incomplete)
                 .action(New)
                 .budget(Duration::hours(3))
                 .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("y", 2, Incomplete)
+            &task("y", 2, Incomplete)
                 .action(New)
                 .budget(Duration::hours(3))
                 .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("z", 3, Incomplete)
+            &task("z", 3, Incomplete)
                 .action(New)
                 .budget(Duration::hours(3))
                 .adeps_stats(0, 1),
         )
-        .printed_task(
-            &PrintableTask::new("a", 4, Blocked)
-                .action(Select)
-                .deps_stats(3, 3),
-        )
+        .printed_task(&task("a", 4, Blocked).action(Select).deps_stats(3, 3))
         .end();
 }
 
@@ -248,28 +189,24 @@ fn split_task_chain_keep_with_budget() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("x", 1, Incomplete)
+            &task("x", 1, Incomplete)
                 .action(New)
                 .budget(Duration::hours(1))
                 .adeps_stats(1, 3),
         )
         .printed_task(
-            &PrintableTask::new("y", 2, Blocked)
+            &task("y", 2, Blocked)
                 .action(New)
                 .budget(Duration::hours(1))
                 .deps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("z", 3, Blocked)
+            &task("z", 3, Blocked)
                 .action(New)
                 .budget(Duration::hours(1))
                 .deps_stats(1, 2),
         )
-        .printed_task(
-            &PrintableTask::new("a", 4, Blocked)
-                .action(Select)
-                .deps_stats(1, 3),
-        )
+        .printed_task(&task("a", 4, Blocked).action(Select).deps_stats(1, 3))
         .end();
 }
 
@@ -280,15 +217,9 @@ fn split_tag_default() {
     fix.test("todo split a --into x y z")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("x", 1, Incomplete).action(New).as_tag(),
-        )
-        .printed_task(
-            &PrintableTask::new("y", 2, Incomplete).action(New).as_tag(),
-        )
-        .printed_task(
-            &PrintableTask::new("z", 3, Incomplete).action(New).as_tag(),
-        )
+        .printed_task(&task("x", 1, Incomplete).action(New).as_tag())
+        .printed_task(&task("y", 2, Incomplete).action(New).as_tag())
+        .printed_task(&task("z", 3, Incomplete).action(New).as_tag())
         .end();
 }
 
@@ -299,9 +230,9 @@ fn split_tag_into_non_tags() {
     fix.test("todo split a --into x y z --tag false")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("x", 1, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("y", 2, Incomplete).action(New))
-        .printed_task(&PrintableTask::new("z", 3, Incomplete).action(New))
+        .printed_task(&task("x", 1, Incomplete).action(New))
+        .printed_task(&task("y", 2, Incomplete).action(New))
+        .printed_task(&task("z", 3, Incomplete).action(New))
         .end();
 }
 
@@ -313,25 +244,25 @@ fn split_tag_keep() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("x", 1, Incomplete)
+            &task("x", 1, Incomplete)
                 .action(New)
                 .tag("a")
                 .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("y", 2, Incomplete)
+            &task("y", 2, Incomplete)
                 .action(New)
                 .tag("a")
                 .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("z", 3, Incomplete)
+            &task("z", 3, Incomplete)
                 .action(New)
                 .tag("a")
                 .adeps_stats(0, 1),
         )
         .printed_task(
-            &PrintableTask::new("a", 4, Blocked)
+            &task("a", 4, Blocked)
                 .action(Select)
                 .as_tag()
                 .deps_stats(3, 3),
@@ -346,26 +277,10 @@ fn trim_leading_whitespace() {
     fix.test("todo split a --into ' a.x' '  a.y' '   a.z' --keep")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a.x", 1, Incomplete)
-                .action(New)
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("a.y", 2, Incomplete)
-                .action(New)
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("a.z", 3, Incomplete)
-                .action(New)
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("a", 4, Blocked)
-                .action(Select)
-                .deps_stats(3, 3),
-        )
+        .printed_task(&task("a.x", 1, Incomplete).action(New).adeps_stats(0, 1))
+        .printed_task(&task("a.y", 2, Incomplete).action(New).adeps_stats(0, 1))
+        .printed_task(&task("a.z", 3, Incomplete).action(New).adeps_stats(0, 1))
+        .printed_task(&task("a", 4, Blocked).action(Select).deps_stats(3, 3))
         .end();
 }
 
@@ -376,25 +291,9 @@ fn trim_trailing_whitespace() {
     fix.test("todo split a --into 'a.x ' 'a.y  ' 'a.z   ' --keep")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a.x", 1, Incomplete)
-                .action(New)
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("a.y", 2, Incomplete)
-                .action(New)
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("a.z", 3, Incomplete)
-                .action(New)
-                .adeps_stats(0, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("a", 4, Blocked)
-                .action(Select)
-                .deps_stats(3, 3),
-        )
+        .printed_task(&task("a.x", 1, Incomplete).action(New).adeps_stats(0, 1))
+        .printed_task(&task("a.y", 2, Incomplete).action(New).adeps_stats(0, 1))
+        .printed_task(&task("a.z", 3, Incomplete).action(New).adeps_stats(0, 1))
+        .printed_task(&task("a", 4, Blocked).action(Select).deps_stats(3, 3))
         .end();
 }

--- a/app/src/status_test.rs
+++ b/app/src/status_test.rs
@@ -1,8 +1,9 @@
 #![allow(clippy::zero_prefixed_literal)]
 
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, PrintableTask, Status::*},
+    printing::{Action::*, Status::*},
     testing::ymdhms,
 };
 
@@ -19,9 +20,9 @@ fn status_after_added_tasks() {
     fix.test("todo")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete))
+        .printed_task(&task("a", 1, Incomplete))
+        .printed_task(&task("b", 2, Incomplete))
+        .printed_task(&task("c", 3, Incomplete))
         .end();
 }
 
@@ -33,8 +34,8 @@ fn status_does_not_include_blocked_tasks() {
     fix.test("todo")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("c", 2, Incomplete))
         .end();
 }
 
@@ -46,8 +47,8 @@ fn include_blocked_in_status() {
     fix.test("todo -b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(&PrintableTask::new("a", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -59,8 +60,8 @@ fn include_complete_in_status() {
     fix.test("todo -d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
+        .printed_task(&task("a", 0, Complete))
+        .printed_task(&task("b", 1, Incomplete))
         .end();
 }
 
@@ -72,9 +73,9 @@ fn include_all_in_status() {
     fix.test("todo -a")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(&PrintableTask::new("c", 2, Blocked).deps_stats(1, 2))
+        .printed_task(&task("a", 0, Complete))
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("c", 2, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -86,7 +87,7 @@ fn status_after_check_multiple_tasks() {
     fix.test("todo")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
+        .printed_task(&task("a", 1, Incomplete))
         .end();
 }
 
@@ -99,8 +100,8 @@ fn status_after_unblocking_task() {
     fix.test("todo")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
+        .printed_task(&task("a", 1, Incomplete))
+        .printed_task(&task("b", 2, Incomplete))
         .end();
 }
 
@@ -115,7 +116,7 @@ fn status_unsnoozes_if_snooze_time_passed() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .start_date(ymdhms(2021, 05, 29, 00, 00, 00))
                 .action(Unsnooze),
         )
@@ -144,17 +145,17 @@ fn status_unsnooze_preserves_order() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .start_date(ymdhms(2021, 05, 30, 13, 00, 00))
                 .action(Unsnooze),
         )
         .printed_task(
-            &PrintableTask::new("b", 2, Incomplete)
+            &task("b", 2, Incomplete)
                 .start_date(ymdhms(2021, 05, 30, 14, 00, 00))
                 .action(Unsnooze),
         )
         .printed_task(
-            &PrintableTask::new("c", 3, Incomplete)
+            &task("c", 3, Incomplete)
                 .start_date(ymdhms(2021, 05, 30, 15, 00, 00))
                 .action(Unsnooze),
         )

--- a/app/src/tag_test.rs
+++ b/app/src/tag_test.rs
@@ -1,6 +1,7 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, PrintableTask, Status::*},
+    printing::{Action::*, Status::*},
 };
 
 #[test]
@@ -17,9 +18,9 @@ fn tag_show_all_tags() {
     fix.test("todo tag")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).as_tag())
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).as_tag())
-        .printed_task(&PrintableTask::new("c", 3, Incomplete).as_tag())
+        .printed_task(&task("a", 1, Incomplete).as_tag())
+        .printed_task(&task("b", 2, Incomplete).as_tag())
+        .printed_task(&task("c", 3, Incomplete).as_tag())
         .end();
 }
 
@@ -31,23 +32,14 @@ fn tag_show_blocked_tags() {
         .modified(false)
         .validate()
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
+            &task("a", 1, Incomplete)
                 .tag("c")
                 .tag("b")
                 .as_tag()
                 .adeps_stats(1, 2),
         )
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .tag("c")
-                .as_tag()
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
-                .as_tag()
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("b", 2, Blocked).tag("c").as_tag().deps_stats(1, 1))
+        .printed_task(&task("c", 3, Blocked).as_tag().deps_stats(1, 2))
         .end();
 }
 
@@ -59,8 +51,8 @@ fn tag_does_not_show_complete_tags_by_default() {
     fix.test("todo tag")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).as_tag())
-        .printed_task(&PrintableTask::new("c", 2, Incomplete).as_tag())
+        .printed_task(&task("b", 1, Incomplete).as_tag())
+        .printed_task(&task("c", 2, Incomplete).as_tag())
         .end();
 }
 
@@ -72,9 +64,9 @@ fn tag_show_complete_tags() {
     fix.test("todo tag --include-done")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).as_tag())
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).as_tag())
-        .printed_task(&PrintableTask::new("c", 2, Incomplete).as_tag())
+        .printed_task(&task("a", 0, Complete).as_tag())
+        .printed_task(&task("b", 1, Incomplete).as_tag())
+        .printed_task(&task("c", 2, Incomplete).as_tag())
         .end();
 }
 
@@ -85,11 +77,7 @@ fn tag_mark_single() {
     fix.test("todo tag a")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .as_tag(),
-        )
+        .printed_task(&task("a", 1, Incomplete).action(Select).as_tag())
         .end();
 }
 
@@ -100,16 +88,8 @@ fn tag_mark_multiple() {
     fix.test("todo tag a b")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .as_tag(),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 2, Incomplete)
-                .action(Select)
-                .as_tag(),
-        )
+        .printed_task(&task("a", 1, Incomplete).action(Select).as_tag())
+        .printed_task(&task("b", 2, Incomplete).action(Select).as_tag())
         .end();
 }
 
@@ -120,11 +100,7 @@ fn tag_mark_already_tag() {
     fix.test("todo tag a")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .as_tag(),
-        )
+        .printed_task(&task("a", 1, Incomplete).action(Select).as_tag())
         .end();
     fix.test("todo tag a").validate().end();
 }
@@ -136,18 +112,10 @@ fn tag_prints_affected_deps_when_marking() {
     fix.test("todo tag c")
         .modified(true)
         .validate()
+        .printed_task(&task("a", 1, Incomplete).tag("c").adeps_stats(1, 2))
+        .printed_task(&task("b", 2, Blocked).tag("c").deps_stats(1, 1))
         .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .tag("c")
-                .adeps_stats(1, 2),
-        )
-        .printed_task(
-            &PrintableTask::new("b", 2, Blocked)
-                .tag("c")
-                .deps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 3, Blocked)
+            &task("c", 3, Blocked)
                 .action(Select)
                 .as_tag()
                 .deps_stats(1, 2),
@@ -161,7 +129,7 @@ fn tag_unmark_single() {
     fix.test("todo new a --tag");
     fix.test("todo tag -u a")
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
+        .printed_task(&task("a", 1, Incomplete).action(Select))
         .end();
 }
 
@@ -172,8 +140,8 @@ fn tag_unmark_multiple() {
     fix.test("todo tag -u a b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Select))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Select))
+        .printed_task(&task("a", 1, Incomplete).action(Select))
+        .printed_task(&task("b", 2, Incomplete).action(Select))
         .end();
 }
 
@@ -192,12 +160,8 @@ fn tag_mark_and_unmark() {
     fix.test("todo tag a -u b")
         .modified(true)
         .validate()
-        .printed_task(
-            &PrintableTask::new("a", 1, Incomplete)
-                .action(Select)
-                .as_tag(),
-        )
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Select))
+        .printed_task(&task("a", 1, Incomplete).action(Select).as_tag())
+        .printed_task(&task("b", 2, Incomplete).action(Select))
         .end();
 }
 
@@ -209,13 +173,9 @@ fn tag_does_not_show_complete_deps_by_default_when_marking() {
     fix.test("todo tag c")
         .modified(true)
         .validate()
+        .printed_task(&task("b", 1, Incomplete).tag("c").adeps_stats(1, 1))
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
-                .tag("c")
-                .adeps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
+            &task("c", 2, Blocked)
                 .action(Select)
                 .as_tag()
                 .deps_stats(1, 2),
@@ -231,14 +191,10 @@ fn tag_show_complete_deps_when_marking() {
     fix.test("todo tag c --include-done")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete).tag("c"))
+        .printed_task(&task("a", 0, Complete).tag("c"))
+        .printed_task(&task("b", 1, Incomplete).tag("c").adeps_stats(1, 1))
         .printed_task(
-            &PrintableTask::new("b", 1, Incomplete)
-                .tag("c")
-                .adeps_stats(1, 1),
-        )
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
+            &task("c", 2, Blocked)
                 .action(Select)
                 .as_tag()
                 .deps_stats(1, 2),
@@ -255,12 +211,8 @@ fn tag_does_not_show_complete_deps_by_default_when_unmarking() {
     fix.test("todo tag -u c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("c", 2, Blocked).action(Select).deps_stats(1, 2))
         .end();
 }
 
@@ -273,12 +225,8 @@ fn tag_show_complete_deps_when_unmarking() {
     fix.test("todo tag -u c -d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(
-            &PrintableTask::new("c", 2, Blocked)
-                .action(Select)
-                .deps_stats(1, 2),
-        )
+        .printed_task(&task("a", 0, Complete))
+        .printed_task(&task("b", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("c", 2, Blocked).action(Select).deps_stats(1, 2))
         .end();
 }

--- a/app/src/testing.rs
+++ b/app/src/testing.rs
@@ -8,7 +8,7 @@ use {
     model::TodoList,
     pretty_assertions::assert_eq,
     printing::{
-        PrintableError, PrintableInfo, PrintableTask, PrintableWarning,
+        PrintableError, PrintableInfo, PrintableTask, PrintableWarning, Status,
         TodoPrinter,
     },
     text_editing::FakeTextEditor,
@@ -153,4 +153,8 @@ impl<'list> Fixture<'list> {
             cmd: s.to_string(),
         }
     }
+}
+
+pub fn task(desc: &str, pos: i32, status: Status) -> PrintableTask<'_> {
+    PrintableTask::new(desc, pos, status)
 }

--- a/app/src/top_test.rs
+++ b/app/src/top_test.rs
@@ -1,7 +1,8 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
     lookup_key::Key,
-    printing::{PrintableTask, PrintableWarning, Status::*},
+    printing::{PrintableWarning, Status::*},
 };
 
 #[test]
@@ -17,9 +18,9 @@ fn top_all_tasks_uncategorized() {
     fix.test("todo top")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete))
+        .printed_task(&task("a", 1, Incomplete))
+        .printed_task(&task("b", 2, Incomplete))
+        .printed_task(&task("c", 3, Incomplete))
         .end();
 }
 
@@ -31,7 +32,7 @@ fn top_all_tasks_categorized_the_same() {
     fix.test("todo top")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("d", 4, Blocked).deps_stats(3, 3))
+        .printed_task(&task("d", 4, Blocked).deps_stats(3, 3))
         .end();
 }
 
@@ -44,8 +45,8 @@ fn top_multiple_categories() {
     fix.test("todo top")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("g", 7, Blocked).deps_stats(3, 3))
-        .printed_task(&PrintableTask::new("h", 8, Blocked).deps_stats(3, 3))
+        .printed_task(&task("g", 7, Blocked).deps_stats(3, 3))
+        .printed_task(&task("h", 8, Blocked).deps_stats(3, 3))
         .end();
 }
 
@@ -57,8 +58,8 @@ fn top_deep_category() {
     fix.test("todo top")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("c", 5, Blocked).deps_stats(1, 2))
-        .printed_task(&PrintableTask::new("f", 6, Blocked).deps_stats(1, 2))
+        .printed_task(&task("c", 5, Blocked).deps_stats(1, 2))
+        .printed_task(&task("f", 6, Blocked).deps_stats(1, 2))
         .end();
 }
 
@@ -70,8 +71,8 @@ fn top_does_not_show_complete_tasks_by_default() {
     fix.test("todo top")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete))
+        .printed_task(&task("b", 1, Incomplete))
+        .printed_task(&task("c", 2, Incomplete))
         .end();
 }
 
@@ -83,9 +84,9 @@ fn top_show_complete_tasks_with_option() {
     fix.test("todo top -d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete))
-        .printed_task(&PrintableTask::new("b", 1, Incomplete))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete))
+        .printed_task(&task("a", 0, Complete))
+        .printed_task(&task("b", 1, Incomplete))
+        .printed_task(&task("c", 2, Incomplete))
         .end();
 }
 
@@ -98,8 +99,8 @@ fn top_show_only_top_level_complete_tasks() {
     fix.test("todo top -d")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("c", -1, Complete))
-        .printed_task(&PrintableTask::new("f", 0, Complete))
+        .printed_task(&task("c", -1, Complete))
+        .printed_task(&task("f", 0, Complete))
         .end();
 }
 
@@ -111,8 +112,8 @@ fn top_underneath_one_task() {
     fix.test("todo top c")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("b", 2, Incomplete).adeps_stats(0, 1))
         .end();
 }
 
@@ -126,12 +127,12 @@ fn top_union_of_categories() {
     fix.test("todo top x y")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete).adeps_stats(0, 2))
-        .printed_task(&PrintableTask::new("d", 4, Incomplete).adeps_stats(0, 2))
-        .printed_task(&PrintableTask::new("e", 5, Incomplete).adeps_stats(0, 1))
-        .printed_task(&PrintableTask::new("f", 6, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("b", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("c", 3, Incomplete).adeps_stats(0, 2))
+        .printed_task(&task("d", 4, Incomplete).adeps_stats(0, 2))
+        .printed_task(&task("e", 5, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("f", 6, Incomplete).adeps_stats(0, 1))
         .end();
 }
 
@@ -146,7 +147,7 @@ fn top_exclude_deps_with_indirect_connection_to_category() {
         // a should be excluded because there's also an indirect connection to
         // the top, through b. On the other hand, b is included because the only
         // path to the top is direct.
-        .printed_task(&PrintableTask::new("b", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -171,6 +172,6 @@ fn top_implicit_include_done() {
     fix.test("todo top b")
         .modified(false)
         .validate()
-        .printed_task(&PrintableTask::new("a", -1, Complete))
+        .printed_task(&task("a", -1, Complete))
         .end();
 }

--- a/app/src/unblock_test.rs
+++ b/app/src/unblock_test.rs
@@ -1,9 +1,10 @@
 use {
+    super::testing::task,
     super::testing::Fixture,
     lookup_key::Key,
     printing::{
         Action::*, BriefPrintableTask, Plicit::*, PrintableError,
-        PrintableTask, PrintableWarning, Status::*,
+        PrintableWarning, Status::*,
     },
 };
 
@@ -15,8 +16,8 @@ fn unblock_task_from_direct_dependency() {
     fix.test("todo unblock 2 --from 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Unlock))
+        .printed_task(&task("a", 1, Incomplete))
+        .printed_task(&task("b", 2, Incomplete).action(Unlock))
         .end();
 }
 
@@ -46,8 +47,8 @@ fn unblock_complete_task() {
     fix.test("todo unblock 0 --from -1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -1, Complete))
-        .printed_task(&PrintableTask::new("b", 0, Complete).action(Unlock))
+        .printed_task(&task("a", -1, Complete))
+        .printed_task(&task("b", 0, Complete).action(Unlock))
         .end();
 }
 
@@ -58,8 +59,8 @@ fn unblock_by_name() {
     fix.test("todo unblock b --from a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete).action(Unlock))
+        .printed_task(&task("a", 1, Incomplete))
+        .printed_task(&task("b", 2, Incomplete).action(Unlock))
         .end();
 }
 
@@ -71,9 +72,9 @@ fn unblock_from_all() {
     fix.test("todo unblock c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete))
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
-        .printed_task(&PrintableTask::new("c", 3, Incomplete).action(Unlock))
+        .printed_task(&task("a", 1, Incomplete))
+        .printed_task(&task("b", 2, Incomplete))
+        .printed_task(&task("c", 3, Incomplete).action(Unlock))
         .end();
 }
 
@@ -85,9 +86,9 @@ fn unblock_from_all2() {
     fix.test("todo unblock c")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(&PrintableTask::new("c", 2, Incomplete).action(Unlock))
-        .printed_task(&PrintableTask::new("b", 3, Blocked).deps_stats(1, 1))
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("c", 2, Incomplete).action(Unlock))
+        .printed_task(&task("b", 3, Blocked).deps_stats(1, 1))
         .end();
 }
 
@@ -99,8 +100,8 @@ fn unblock_complete() {
     fix.test("todo unblock b")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", -1, Complete))
-        .printed_task(&PrintableTask::new("b", 0, Complete).action(Unlock))
+        .printed_task(&task("a", -1, Complete))
+        .printed_task(&task("b", 0, Complete).action(Unlock))
         .end();
 }
 
@@ -128,20 +129,18 @@ fn unblock_updates_priority() {
         .validate()
         // c is printed first, because its priority is higher.
         .printed_task(
-            &PrintableTask::new("c", 1, Incomplete)
+            &task("c", 1, Incomplete)
                 .action(Unlock)
                 .priority(Explicit(2)),
         )
         // a and b have their priorities reset to 1.
         .printed_task(
-            &PrintableTask::new("a", 2, Incomplete)
+            &task("a", 2, Incomplete)
                 .priority(Explicit(1))
                 .adeps_stats(1, 1),
         )
         .printed_task(
-            &PrintableTask::new("b", 3, Blocked)
-                .priority(Explicit(1))
-                .deps_stats(1, 1),
+            &task("b", 3, Blocked).priority(Explicit(1)).deps_stats(1, 1),
         )
         .end();
 }
@@ -156,14 +155,12 @@ fn unblock_does_not_show_unaffected_priority() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("c", 2, Incomplete)
+            &task("c", 2, Incomplete)
                 .action(Unlock)
                 .priority(Explicit(1)),
         )
         .printed_task(
-            &PrintableTask::new("b", 3, Blocked)
-                .priority(Explicit(1))
-                .deps_stats(1, 1),
+            &task("b", 3, Blocked).priority(Explicit(1)).deps_stats(1, 1),
         )
         .end();
 }
@@ -178,11 +175,11 @@ fn unblock_excludes_affected_complete_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &PrintableTask::new("c", 1, Incomplete)
+            &task("c", 1, Incomplete)
                 .priority(Explicit(1))
                 .action(Unlock),
         )
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
+        .printed_task(&task("b", 2, Incomplete))
         .end();
 }
 
@@ -195,12 +192,12 @@ fn unblock_include_done() {
     fix.test("todo unblock c --from b -d")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 0, Complete))
+        .printed_task(&task("a", 0, Complete))
         .printed_task(
-            &PrintableTask::new("c", 1, Incomplete)
+            &task("c", 1, Incomplete)
                 .priority(Explicit(1))
                 .action(Unlock),
         )
-        .printed_task(&PrintableTask::new("b", 2, Incomplete))
+        .printed_task(&task("b", 2, Incomplete))
         .end();
 }

--- a/app/src/unsnooze_test.rs
+++ b/app/src/unsnooze_test.rs
@@ -1,11 +1,9 @@
 #![allow(clippy::zero_prefixed_literal)]
 
 use {
+    super::testing::task,
     super::testing::Fixture,
-    printing::{
-        Action::*, BriefPrintableTask, PrintableTask, PrintableWarning,
-        Status::*,
-    },
+    printing::{Action::*, BriefPrintableTask, PrintableWarning, Status::*},
     testing::ymdhms,
 };
 
@@ -17,7 +15,7 @@ fn unsnooze_snoozed_task() {
     fix.test("todo unsnooze 1")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 1, Incomplete).action(Unsnooze))
+        .printed_task(&task("a", 1, Incomplete).action(Unsnooze))
         .end();
 }
 
@@ -30,7 +28,7 @@ fn unsnoozed_task_appears_at_end_of_incomplete_list() {
     fix.test("todo unsnooze a")
         .modified(true)
         .validate()
-        .printed_task(&PrintableTask::new("a", 3, Incomplete).action(Unsnooze))
+        .printed_task(&task("a", 3, Incomplete).action(Unsnooze))
         .end();
 }
 

--- a/app/src/util_test.rs
+++ b/app/src/util_test.rs
@@ -1,11 +1,12 @@
 #![allow(clippy::zero_prefixed_literal)]
 
 use {
+    super::testing::task,
     super::util::*,
     chrono::Duration,
     lookup_key::Key,
     model::{CheckOptions, NewOptions, TodoList},
-    printing::{Action::*, Plicit::*, PrintableTask, Status::*},
+    printing::{Action::*, Plicit::*, Status::*},
     testing::ymdhms,
 };
 
@@ -14,7 +15,7 @@ fn format_task_basic() {
     let mut list = TodoList::default();
     let a = list.add("a");
     let actual = format_task(&list, a);
-    let expected = PrintableTask::new("a", 1, Incomplete);
+    let expected = task("a", 1, Incomplete);
     assert_eq!(actual, expected);
 }
 
@@ -23,7 +24,7 @@ fn format_task_with_action() {
     let mut list = TodoList::default();
     let a = list.add("a");
     let actual = format_task(&list, a).action(Punt);
-    let expected = PrintableTask::new("a", 1, Incomplete).action(Punt);
+    let expected = task("a", 1, Incomplete).action(Punt);
     assert_eq!(actual, expected);
 }
 
@@ -32,7 +33,7 @@ fn format_task_with_priority() {
     let mut list = TodoList::default();
     let a = list.add(NewOptions::new().desc("a").priority(1));
     let actual = format_task(&list, a);
-    let expected = PrintableTask::new("a", 1, Incomplete).priority(Explicit(1));
+    let expected = task("a", 1, Incomplete).priority(Explicit(1));
     assert_eq!(actual, expected);
 }
 
@@ -41,7 +42,7 @@ fn format_task_with_zero_priority() {
     let mut list = TodoList::default();
     let a = list.add(NewOptions::new().desc("a").priority(0));
     let actual = format_task(&list, a);
-    let expected = PrintableTask::new("a", 1, Incomplete);
+    let expected = task("a", 1, Incomplete);
     assert_eq!(actual, expected);
 }
 
@@ -57,7 +58,7 @@ fn format_task_with_budget() {
             .due_date(due),
     );
     let actual = format_task(&list, a);
-    let expected = PrintableTask::new("a", 1, Incomplete)
+    let expected = task("a", 1, Incomplete)
         .due_date(Explicit(due))
         .budget(Duration::hours(10));
     assert_eq!(actual, expected);
@@ -72,7 +73,7 @@ fn format_incomplete_task_with_adep_stats() {
     list.block(b).on(a).unwrap();
     list.block(c).on(b).unwrap();
     let actual = format_task(&list, a);
-    let expected = PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 2);
+    let expected = task("a", 1, Incomplete).adeps_stats(1, 2);
     assert_eq!(actual, expected);
 }
 
@@ -85,7 +86,7 @@ fn format_incomplete_task_with_all_all_adeps_unlockable() {
     list.block(b).on(a).unwrap();
     list.block(c).on(a).unwrap();
     let actual = format_task(&list, a);
-    let expected = PrintableTask::new("a", 1, Incomplete).adeps_stats(2, 2);
+    let expected = task("a", 1, Incomplete).adeps_stats(2, 2);
     assert_eq!(actual, expected);
 }
 
@@ -144,7 +145,7 @@ fn format_incomplete_task_with_long_adep_chain() {
     list.block(y).on(x).unwrap();
     list.block(z).on(y).unwrap();
     let actual = format_task(&list, a);
-    let expected = PrintableTask::new("a", 1, Incomplete).adeps_stats(1, 25);
+    let expected = task("a", 1, Incomplete).adeps_stats(1, 25);
     assert_eq!(actual, expected);
 }
 
@@ -157,7 +158,7 @@ fn format_blocked_task_with_two_deps() {
     list.block(c).on(a).unwrap();
     list.block(c).on(b).unwrap();
     let actual = format_task(&list, c);
-    let expected = PrintableTask::new("c", 3, Blocked).deps_stats(2, 2);
+    let expected = task("c", 3, Blocked).deps_stats(2, 2);
     assert_eq!(actual, expected);
 }
 
@@ -168,7 +169,7 @@ fn format_blocked_task_with_one_dep() {
     let b = list.add("b");
     list.block(b).on(a).unwrap();
     let actual = format_task(&list, b);
-    let expected = PrintableTask::new("b", 2, Blocked).deps_stats(1, 1);
+    let expected = task("b", 2, Blocked).deps_stats(1, 1);
     assert_eq!(actual, expected);
 }
 
@@ -182,7 +183,7 @@ fn format_blocked_task_with_complete_deps() {
     list.block(c).on(b).unwrap();
     list.check(a).unwrap();
     let actual = format_task(&list, c);
-    let expected = PrintableTask::new("c", 2, Blocked).deps_stats(1, 2);
+    let expected = task("c", 2, Blocked).deps_stats(1, 2);
     assert_eq!(actual, expected);
 }
 
@@ -195,7 +196,7 @@ fn format_blocked_task_with_blocked_deps() {
     list.block(b).on(a).unwrap();
     list.block(c).on(b).unwrap();
     let actual = format_task(&list, c);
-    let expected = PrintableTask::new("c", 3, Blocked).deps_stats(1, 2);
+    let expected = task("c", 3, Blocked).deps_stats(1, 2);
     assert_eq!(actual, expected);
 }
 
@@ -208,7 +209,7 @@ fn format_blocked_task_with_deps_and_adeps() {
     list.block(b).on(a).unwrap();
     list.block(c).on(b).unwrap();
     let actual = format_task(&list, b);
-    let expected = PrintableTask::new("b", 2, Blocked).deps_stats(1, 1);
+    let expected = task("b", 2, Blocked).deps_stats(1, 1);
     assert_eq!(actual, expected);
 }
 
@@ -224,7 +225,7 @@ fn format_complete_task_does_not_show_deps_or_adeps() {
     list.check(b).unwrap();
     list.check(c).unwrap();
     let actual = format_task(&list, b);
-    let expected = PrintableTask::new("b", -1, Complete);
+    let expected = task("b", -1, Complete);
     assert_eq!(actual, expected);
 }
 
@@ -236,7 +237,7 @@ fn format_incomplete_task_does_not_show_deps() {
     list.block(b).on(a).unwrap();
     list.check(a).unwrap();
     let actual = format_task(&list, b);
-    let expected = PrintableTask::new("b", 1, Incomplete);
+    let expected = task("b", 1, Incomplete);
     assert_eq!(actual, expected);
 }
 
@@ -252,8 +253,8 @@ fn format_complete_task_with_punctuality_early() {
     );
     list.check(CheckOptions { id: a, now }).unwrap();
     let actual = format_task(&list, a);
-    let expected = PrintableTask::new("a", 0, Complete)
-        .punctuality(-chrono::Duration::hours(2));
+    let expected =
+        task("a", 0, Complete).punctuality(-chrono::Duration::hours(2));
     assert_eq!(actual, expected);
 }
 
@@ -269,8 +270,8 @@ fn format_complete_task_with_punctuality_late() {
     );
     list.check(CheckOptions { id: a, now }).unwrap();
     let actual = format_task(&list, a);
-    let expected = PrintableTask::new("a", 0, Complete)
-        .punctuality(chrono::Duration::days(3));
+    let expected =
+        task("a", 0, Complete).punctuality(chrono::Duration::days(3));
     assert_eq!(actual, expected);
 }
 
@@ -279,7 +280,7 @@ fn format_tag() {
     let mut list = TodoList::default();
     let a = list.add(NewOptions::new().desc("a").as_tag());
     let actual = format_task(&list, a);
-    let expected = PrintableTask::new("a", 1, Incomplete).as_tag();
+    let expected = task("a", 1, Incomplete).as_tag();
     assert_eq!(actual, expected);
 }
 
@@ -292,10 +293,7 @@ fn format_task_with_implicit_tags() {
     list.block(a).on(c).unwrap();
     list.block(b).on(c).unwrap();
     let actual = format_task(&list, c);
-    let expected = PrintableTask::new("c", 1, Incomplete)
-        .adeps_stats(2, 2)
-        .tag("a")
-        .tag("b");
+    let expected = task("c", 1, Incomplete).adeps_stats(2, 2).tag("a").tag("b");
     assert_eq!(actual, expected);
 }
 
@@ -308,7 +306,7 @@ fn format_tag_with_implicit_tags() {
     list.block(a).on(c).unwrap();
     list.block(b).on(c).unwrap();
     let actual = format_task(&list, c);
-    let expected = PrintableTask::new("c", 1, Incomplete)
+    let expected = task("c", 1, Incomplete)
         .adeps_stats(2, 2)
         .tag("a")
         .tag("b")

--- a/printing/src/lib.rs
+++ b/printing/src/lib.rs
@@ -22,6 +22,8 @@ mod printable_error_test;
 #[cfg(test)]
 mod printable_info_test;
 #[cfg(test)]
+mod printable_task_test;
+#[cfg(test)]
 mod printable_warning_test;
 #[cfg(test)]
 mod simple_todo_printer_test;


### PR DESCRIPTION
The new task() helper function is a more concise version of
PrintableTask::new(). This allows a lot of printable task builders to
fit on one line and make tests visually more compact.