### PR TITLE
Display tags in reverse sorted order.

### DIFF
--- a/app/src/edit_test.rs
+++ b/app/src/edit_test.rs
@@ -269,10 +269,10 @@ fn rename_tag_with_text_editor_and_multiple_tasks() {
         .modified(true)
         .validate()
         .printed_task(
-            &task("a", 1, Incomplete).tag("y").tag("z").adeps_stats(0, 2),
+            &task("a", 1, Incomplete).tag("z").tag("y").adeps_stats(0, 2),
         )
         .printed_task(
-            &task("b", 2, Incomplete).tag("y").tag("z").adeps_stats(0, 2),
+            &task("b", 2, Incomplete).tag("z").tag("y").adeps_stats(0, 2),
         )
         .printed_task(&task("y", 3, Blocked).as_tag().deps_stats(2, 2))
         .printed_task(&task("z", 4, Blocked).as_tag().deps_stats(2, 2))

--- a/app/src/util.rs
+++ b/app/src/util.rs
@@ -130,8 +130,10 @@ pub fn format_task<'list>(
             if task.tag {
                 result = result.as_tag();
             }
-            for tag_id in &task.implicit_tags {
-                if let Some(tag_data) = list.get(*tag_id) {
+            for tag_id in TaskSet::from_iter(task.implicit_tags.iter().cloned())
+                .iter_sorted(list).rev()
+            {
+                if let Some(tag_data) = list.get(tag_id) {
                     result = result.tag(&tag_data.desc);
                 }
             }

--- a/app/src/util_test.rs
+++ b/app/src/util_test.rs
@@ -294,7 +294,7 @@ fn format_task_with_implicit_tags() {
     list.block(a).on(c).unwrap();
     list.block(b).on(c).unwrap();
     let actual = format_task(&list, c);
-    let expected = task("c", 1, Incomplete).adeps_stats(2, 2).tag("a").tag("b");
+    let expected = task("c", 1, Incomplete).adeps_stats(2, 2).tag("b").tag("a");
     assert_eq!(actual, expected);
 }
 
@@ -309,8 +309,8 @@ fn format_tag_with_implicit_tags() {
     let actual = format_task(&list, c);
     let expected = task("c", 1, Incomplete)
         .adeps_stats(2, 2)
-        .tag("a")
         .tag("b")
+        .tag("a")
         .as_tag();
     assert_eq!(actual, expected);
 }
@@ -368,4 +368,25 @@ fn lookup_by_range() {
     assert_eq!(lookup_2_3.as_sorted_vec(&list), [b, c]);
     let lookup_1_3 = lookup_tasks(&list, &[Key::ByRange(1, 3)]);
     assert_eq!(lookup_1_3.as_sorted_vec(&list), [a, b, c]);
+}
+
+#[test]
+fn tags_are_formatted_in_reverse_sorted_order() {
+    let mut list = TodoList::default();
+    let a = list.add("a");
+    let b = list.add(NewOptions::new().desc("b").as_tag());
+    let c = list.add(NewOptions::new().desc("c").as_tag().priority(1));
+    let d = list.add(NewOptions::new().desc("d").as_tag());
+    list.block(b).on(a).unwrap();
+    list.block(c).on(a).unwrap();
+    list.block(d).on(b).unwrap();
+    assert_eq!(list.all_tasks().collect::<Vec<_>>(), [a, c, b, d]);
+    let actual = format_task(&list, a);
+    let expected = task("a", 1, Incomplete)
+        .adeps_stats(2, 3)
+        .tag("d")
+        .tag("b")
+        .tag("c")
+        .priority(Implicit(1));
+    assert_eq!(actual, expected);
 }

--- a/model/src/task_set.rs
+++ b/model/src/task_set.rs
@@ -65,7 +65,10 @@ impl TaskSet {
 
     /// Iterates the set in sorted order, where the ordering is defined by the
     /// position in the list.
-    pub fn iter_sorted(&self, list: &TodoList) -> impl Iterator<Item = TaskId> {
+    pub fn iter_sorted(
+        &self,
+        list: &TodoList,
+    ) -> impl DoubleEndedIterator<Item = TaskId> {
         self.ids
             .iter()
             .flat_map(|&id| {


### PR DESCRIPTION
This allows more "general" tags to appear first, and work from left to right progressing from "general" to "specific". This also has higher-priority tags appear closer to the right, closer to the description. Furthermore, this leaves the order that the tags are displayed independent of the order in which the tags were applied, so adjacent tasks with the same tags will show their tags in the same order.