### PR TITLE
Snoozed tasks are not put in a higher layer.

### DIFF
--- a/app/src/snooze.rs
+++ b/app/src/snooze.rs
@@ -52,11 +52,9 @@ pub fn run<'list>(
     if snooze_date <= now {
         let warnings = lookup_tasks(list, &cmd.keys)
             .iter_sorted(list)
-            .map(|id| {
-                PrintableWarning::SnoozedUntilPast {
-                    snoozed_task: format_task_brief(list, id),
-                    snooze_date,
-                }
+            .map(|id| PrintableWarning::SnoozedUntilPast {
+                snoozed_task: format_task_brief(list, id),
+                snooze_date,
             })
             .collect();
         return Ok(PrintableAppSuccess {

--- a/app/src/status_test.rs
+++ b/app/src/status_test.rs
@@ -115,11 +115,7 @@ fn status_unsnoozes_if_snooze_time_passed() {
     fix.test("todo")
         .modified(true)
         .validate()
-        .printed_task(
-            &task("a", 1, Incomplete)
-                .start_date(ymdhms(2021, 05, 29, 00, 00, 00))
-                .action(Unsnooze),
-        )
+        .printed_task(&task("a", 1, Incomplete).action(Unsnooze))
         .end();
 }
 
@@ -144,20 +140,8 @@ fn status_unsnooze_preserves_order() {
     fix.test("todo")
         .modified(true)
         .validate()
-        .printed_task(
-            &task("a", 1, Incomplete)
-                .start_date(ymdhms(2021, 05, 30, 13, 00, 00))
-                .action(Unsnooze),
-        )
-        .printed_task(
-            &task("b", 2, Incomplete)
-                .start_date(ymdhms(2021, 05, 30, 14, 00, 00))
-                .action(Unsnooze),
-        )
-        .printed_task(
-            &task("c", 3, Incomplete)
-                .start_date(ymdhms(2021, 05, 30, 15, 00, 00))
-                .action(Unsnooze),
-        )
+        .printed_task(&task("a", 1, Incomplete).action(Unsnooze))
+        .printed_task(&task("b", 2, Incomplete).action(Unsnooze))
+        .printed_task(&task("c", 3, Incomplete).action(Unsnooze))
         .end();
 }

--- a/app/src/unsnooze_test.rs
+++ b/app/src/unsnooze_test.rs
@@ -62,17 +62,14 @@ fn show_warning_when_unsnoozing_complete_task() {
 }
 
 #[test]
-fn show_warning_when_unsnoozing_blocked_task() {
+fn unsnooze_blocked_task() {
     let mut fix = Fixture::default();
     fix.clock.now = ymdhms(2022, 02, 22, 10, 00, 00);
     fix.test("todo new a b --chain");
     fix.test("todo snooze b --until 1 hour");
     fix.test("todo unsnooze b")
-        .modified(false)
+        .modified(true)
         .validate()
-        .printed_warning(&PrintableWarning::CannotUnsnoozeBecauseBlocked {
-            cannot_unsnooze: BriefPrintableTask::new(2, Blocked),
-            blocked_by: vec![BriefPrintableTask::new(1, Incomplete)],
-        })
+        .printed_task(&task("b", 2, Blocked).deps_stats(1, 1).action(Unsnooze))
         .end();
 }

--- a/model/src/task.rs
+++ b/model/src/task.rs
@@ -136,4 +136,8 @@ impl<'ser> Task<'ser> {
             implicit_tags: vec![],
         }
     }
+
+    pub(crate) fn is_snoozed(&self) -> bool {
+        self.start_date > self.creation_time
+    }
 }


### PR DESCRIPTION
Before, a snoozed task whose natural depth was 0 (i.e. it had no incomplete dependencies) would be put in layer 1, as if it had incomplete dependencies after all. This was meant to sort them after unblocked incomplete tasks but before blocked tasks on layer 1.

However, it was possible for a snoozed task to be sorted after actually blocked tasks, including tasks that the snoozed task was blocking, which would violate the intended invariant that tasks would always be sorted after their dependencies.

The new approach uses whether a task is snoozed to determine the first comparison when sorting tasks, so that a snoozed task always appears after all unsnoozed tasks on the same layer. This generalizes snoozed tasks to layers other than 0 and 1, which can be useful if you want to snooze a blocked task so that it won't appear right away when you complete its dependencies.

This should be a fully backwards-compatible change: all tasks are considered for unsnoozing no matter what layer they are on, and once their start date passes, they will be put on the correct layer. No fields have been added or removed from the data model. We use the fact of whether the start date is the same as the creation date to determine whether the task is snoozed in order to avoid having to add a new field to the data model.