### PR TITLE
Finally get the .workspace syntax working in all the Cargo.toml files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,38 @@
 [workspace]
 resolver = "2"
-members = [
-    "cli",
-    "clock",
-    "config",
-    "lookup_key",
-    "main",
-    "model",
-    "printing",
-    "testing",
-    "text_editing",
-    "time_format",
-]
+members = ["main"]
+
+[workspace.dependencies]
+# cratets.io dependencies
+ansi_term = "0.12"
+bisection = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4.0.*", features = ["derive"] }
+daggy = { version = "0.8", features = ["serde-1", "stable_dag"] }
+directories = "5.0"
+humantime = "2.1"
+itertools = "0.11"
+pretty_assertions = "1.1"
+scrawl = "2.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+shlex = "1.1.0"
+term_size = "0.3"
+textwrap = "0.16.0"
+thiserror = "1.0.30"
+
+# Local dependencies
+app = { path = "app" }
+cli = { path = "cli" }
+clock = { path = "clock" }
+config = { path = "config" }
+lookup_key = { path = "lookup_key" }
+main = { path = "main" }
+model = { path = "model" }
+printing = { path = "printing" }
+testing = { path = "testing" }
+text_editing = { path = "text_editing" }
+time_format = { path = "time_format" }
 
 [profile.dev]
 split-debuginfo = "packed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,16 @@ textwrap = "0.16.0"
 thiserror = "1.0.30"
 
 # Local dependencies
-app = { path = "app" }
-cli = { path = "cli" }
-clock = { path = "clock" }
-config = { path = "config" }
-lookup_key = { path = "lookup_key" }
-main = { path = "main" }
-model = { path = "model" }
-printing = { path = "printing" }
-testing = { path = "testing" }
-text_editing = { path = "text_editing" }
-time_format = { path = "time_format" }
+todo_app = { path = "app" }
+todo_cli = { path = "cli" }
+todo_clock = { path = "clock" }
+todo_config = { path = "config" }
+todo_lookup_key = { path = "lookup_key" }
+todo_model = { path = "model" }
+todo_printing = { path = "printing" }
+todo_testing = { path = "testing" }
+todo_text_editing = { path = "text_editing" }
+todo_time_format = { path = "time_format" }
 
 [profile.dev]
 split-debuginfo = "packed"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "app"
+name = "todo_app"
 version = "0.1.0"
 edition = "2021"
 
@@ -10,14 +10,14 @@ humantime.workspace = true
 itertools.workspace = true
 shlex.workspace = true
 
-cli.workspace = true
-clock.workspace = true
-lookup_key.workspace = true
-model.workspace = true
-printing.workspace = true
-testing.workspace = true
-text_editing.workspace = true
-time_format.workspace = true
+todo_cli.workspace = true
+todo_clock.workspace = true
+todo_lookup_key.workspace = true
+todo_model.workspace = true
+todo_printing.workspace = true
+todo_testing.workspace = true
+todo_text_editing.workspace = true
+todo_time_format.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -4,20 +4,20 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
-clap = "4.0.*"
-humantime = "2.1"
-itertools = "0.11"
-shlex = "1.1.0"
+chrono.workspace = true
+clap.workspace = true
+humantime.workspace = true
+itertools.workspace = true
+shlex.workspace = true
 
-cli = { path = "../cli" }
-clock = { path = "../clock" }
-lookup_key = { path = "../lookup_key" }
-model = { path = "../model" }
-printing = { path = "../printing" }
-testing = { path = "../testing" }
-text_editing = { path = "../text_editing" }
-time_format = { path = "../time_format" }
+cli.workspace = true
+clock.workspace = true
+lookup_key.workspace = true
+model.workspace = true
+printing.workspace = true
+testing.workspace = true
+text_editing.workspace = true
+time_format.workspace = true
 
 [dev-dependencies]
-pretty_assertions = "1.3.0"
+pretty_assertions.workspace = true

--- a/app/src/block.rs
+++ b/app/src/block.rs
@@ -2,9 +2,11 @@ use {
     super::util::{
         format_task, format_task_brief, lookup_tasks, should_include_done,
     },
-    cli::Block,
-    model::{TaskId, TaskSet, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableError, PrintableResult},
+    todo_cli::Block,
+    todo_model::{TaskId, TaskSet, TodoList},
+    todo_printing::{
+        Action, PrintableAppSuccess, PrintableError, PrintableResult,
+    },
 };
 
 fn to_error(list: &TodoList, a: TaskId, b: TaskId) -> Vec<PrintableError> {

--- a/app/src/block_test.rs
+++ b/app/src/block_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{
+    todo_printing::{
         Action::*, BriefPrintableTask, Plicit::*, PrintableError, Status::*,
     },
 };

--- a/app/src/bottom.rs
+++ b/app/src/bottom.rs
@@ -1,6 +1,6 @@
-use cli::Bottom;
-use model::{TaskId, TaskSet, TaskStatus, TodoList};
-use printing::{PrintableAppSuccess, PrintableResult, PrintableWarning};
+use todo_cli::Bottom;
+use todo_model::{TaskId, TaskSet, TaskStatus, TodoList};
+use todo_printing::{PrintableAppSuccess, PrintableResult, PrintableWarning};
 
 use crate::util::{format_task, lookup_task, should_include_done};
 

--- a/app/src/bottom_test.rs
+++ b/app/src/bottom_test.rs
@@ -1,8 +1,8 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    lookup_key::Key,
-    printing::{PrintableWarning, Status::*},
+    todo_lookup_key::Key,
+    todo_printing::{PrintableWarning, Status::*},
 };
 
 #[test]

--- a/app/src/budget.rs
+++ b/app/src/budget.rs
@@ -2,9 +2,9 @@ use {
     super::util::{
         format_task, lookup_tasks, parse_budget, should_include_done,
     },
-    cli::Budget,
-    model::{TaskSet, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableResult},
+    todo_cli::Budget,
+    todo_model::{TaskSet, TodoList},
+    todo_printing::{Action, PrintableAppSuccess, PrintableResult},
 };
 
 pub fn run<'list>(

--- a/app/src/budget_test.rs
+++ b/app/src/budget_test.rs
@@ -4,8 +4,8 @@ use {
     super::testing::task,
     super::testing::Fixture,
     chrono::Duration,
-    printing::{Action::*, Plicit::*, PrintableError, Status::*},
-    testing::ymdhms,
+    todo_printing::{Action::*, Plicit::*, PrintableError, Status::*},
+    todo_testing::ymdhms,
 };
 
 #[test]

--- a/app/src/chain.rs
+++ b/app/src/chain.rs
@@ -2,10 +2,12 @@ use {
     super::util::{
         format_task, format_task_brief, lookup_task, should_include_done,
     },
-    cli::Chain,
-    model::{BlockError, TaskSet, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableError, PrintableResult},
     std::collections::HashMap,
+    todo_cli::Chain,
+    todo_model::{BlockError, TaskSet, TodoList},
+    todo_printing::{
+        Action, PrintableAppSuccess, PrintableError, PrintableResult,
+    },
 };
 
 pub fn run<'list>(

--- a/app/src/chain_test.rs
+++ b/app/src/chain_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{
+    todo_printing::{
         Action::*, BriefPrintableTask, Plicit::*, PrintableError, Status::*,
     },
 };

--- a/app/src/check.rs
+++ b/app/src/check.rs
@@ -1,11 +1,11 @@
 use {
     super::util::{format_task, format_task_brief, lookup_tasks},
     chrono::{DateTime, Utc},
-    cli::Check,
-    model::{
+    todo_cli::Check,
+    todo_model::{
         CheckError, CheckOptions, ForceChecked, TaskId, TaskSet, TodoList,
     },
-    printing::{
+    todo_printing::{
         Action, PrintableAppSuccess, PrintableError, PrintableResult,
         PrintableWarning,
     },

--- a/app/src/check_test.rs
+++ b/app/src/check_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{
+    todo_printing::{
         Action::*, BriefPrintableTask, PrintableError, PrintableWarning,
         Status::*,
     },

--- a/app/src/due.rs
+++ b/app/src/due.rs
@@ -1,9 +1,9 @@
 use {
     super::util::{format_task, lookup_tasks, parse_due_date},
     chrono::{DateTime, Utc},
-    cli::Due,
-    model::{TaskId, TaskSet, TaskStatus, TodoList},
-    printing::{PrintableAppSuccess, PrintableError, PrintableResult},
+    todo_cli::Due,
+    todo_model::{TaskId, TaskSet, TaskStatus, TodoList},
+    todo_printing::{PrintableAppSuccess, PrintableError, PrintableResult},
 };
 
 fn show_all_tasks_with_due_dates<'list>(

--- a/app/src/due_test.rs
+++ b/app/src/due_test.rs
@@ -3,8 +3,8 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{Plicit::*, PrintableError, Status::*},
-    testing::ymdhms,
+    todo_printing::{Plicit::*, PrintableError, Status::*},
+    todo_testing::ymdhms,
 };
 
 #[test]

--- a/app/src/edit.rs
+++ b/app/src/edit.rs
@@ -1,13 +1,13 @@
-use printing::{PrintableAppSuccess, PrintableResult};
+use todo_printing::{PrintableAppSuccess, PrintableResult};
 
 use {
     super::util::{format_task, lookup_tasks},
-    cli::Edit,
     itertools::Itertools,
-    model::{TaskSet, TodoList},
-    printing::PrintableError,
     std::borrow::Cow,
-    text_editing::TextEditor,
+    todo_cli::Edit,
+    todo_model::{TaskSet, TodoList},
+    todo_printing::PrintableError,
+    todo_text_editing::TextEditor,
 };
 
 pub const EDIT_PROMPT: &str = r"# Edit the descriptions of the tasks below.

--- a/app/src/edit_test.rs
+++ b/app/src/edit_test.rs
@@ -1,8 +1,8 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{PrintableError, Status::*},
-    text_editing::FakeTextEditor,
+    todo_printing::{PrintableError, Status::*},
+    todo_text_editing::FakeTextEditor,
 };
 
 fn prompt_with(stuff: &str) -> String {

--- a/app/src/find.rs
+++ b/app/src/find.rs
@@ -1,8 +1,8 @@
 use {
     super::util::format_task,
-    cli::Find,
-    model::{TaskStatus, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableResult},
+    todo_cli::Find,
+    todo_model::{TaskStatus, TodoList},
+    todo_printing::{Action, PrintableAppSuccess, PrintableResult},
 };
 
 pub fn run<'list>(list: &'list TodoList, cmd: &Find) -> PrintableResult<'list> {

--- a/app/src/find_test.rs
+++ b/app/src/find_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{Action::Select, Status::*},
+    todo_printing::{Action::Select, Status::*},
 };
 
 #[test]

--- a/app/src/get.rs
+++ b/app/src/get.rs
@@ -1,8 +1,8 @@
 use {
     super::util::{format_task, lookup_tasks, should_include_done},
-    cli::Get,
-    model::{TaskSet, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableResult},
+    todo_cli::Get,
+    todo_model::{TaskSet, TodoList},
+    todo_printing::{Action, PrintableAppSuccess, PrintableResult},
 };
 
 pub fn run<'list>(list: &'list TodoList, cmd: &Get) -> PrintableResult<'list> {

--- a/app/src/get_test.rs
+++ b/app/src/get_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, Status::*},
+    todo_printing::{Action::*, Status::*},
 };
 
 #[test]

--- a/app/src/log.rs
+++ b/app/src/log.rs
@@ -1,8 +1,8 @@
 use {
     super::util::format_task,
     chrono::{Datelike, Local},
-    model::TodoList,
-    printing::{LogDate, PrintableAppSuccess, PrintableResult},
+    todo_model::TodoList,
+    todo_printing::{LogDate, PrintableAppSuccess, PrintableResult},
 };
 
 pub fn run<'list>(list: &'list TodoList) -> PrintableResult<'list> {

--- a/app/src/log_test.rs
+++ b/app/src/log_test.rs
@@ -4,7 +4,7 @@ use {
     super::testing::task,
     super::testing::Fixture,
     chrono::{Local, TimeZone, Utc},
-    printing::{LogDate::*, Status::*},
+    todo_printing::{LogDate::*, Status::*},
 };
 
 #[test]

--- a/app/src/merge.rs
+++ b/app/src/merge.rs
@@ -1,10 +1,12 @@
 use {
     super::util::{format_task, format_tasks_brief, lookup_tasks},
     chrono::{DateTime, Utc},
-    cli::Merge,
-    model::{DurationInSeconds, NewOptions, TaskSet, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableError, PrintableResult},
     std::borrow::Cow,
+    todo_cli::Merge,
+    todo_model::{DurationInSeconds, NewOptions, TaskSet, TodoList},
+    todo_printing::{
+        Action, PrintableAppSuccess, PrintableError, PrintableResult,
+    },
 };
 
 pub fn run<'list>(

--- a/app/src/merge_test.rs
+++ b/app/src/merge_test.rs
@@ -3,10 +3,10 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{
+    todo_printing::{
         Action::*, BriefPrintableTask, Plicit::*, PrintableError, Status::*,
     },
-    testing::ymdhms,
+    todo_testing::ymdhms,
 };
 
 #[test]

--- a/app/src/new.rs
+++ b/app/src/new.rs
@@ -4,10 +4,12 @@ use {
         parse_budget, parse_due_date, parse_snooze_date,
     },
     chrono::{DateTime, Utc},
-    cli::New,
-    model::{CheckError, CheckOptions, NewOptions, TaskSet, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableError, PrintableResult},
     std::{borrow::Cow, collections::HashSet, iter::FromIterator},
+    todo_cli::New,
+    todo_model::{CheckError, CheckOptions, NewOptions, TaskSet, TodoList},
+    todo_printing::{
+        Action, PrintableAppSuccess, PrintableError, PrintableResult,
+    },
 };
 
 pub fn run<'list>(

--- a/app/src/new_test.rs
+++ b/app/src/new_test.rs
@@ -4,10 +4,10 @@ use {
     super::testing::task,
     super::testing::Fixture,
     chrono::Duration,
-    printing::{
+    todo_printing::{
         Action::*, BriefPrintableTask, Plicit::*, PrintableError, Status::*,
     },
-    testing::ymdhms,
+    todo_testing::ymdhms,
 };
 
 #[test]

--- a/app/src/path.rs
+++ b/app/src/path.rs
@@ -2,9 +2,9 @@ use {
     super::util::{
         format_task, format_task_brief, format_tasks_brief, lookup_task,
     },
-    cli::Path,
-    model::{TaskId, TaskSet, TodoList},
-    printing::{
+    todo_cli::Path,
+    todo_model::{TaskId, TaskSet, TodoList},
+    todo_printing::{
         Action, PrintableAppSuccess, PrintableResult, PrintableWarning,
     },
 };

--- a/app/src/path_test.rs
+++ b/app/src/path_test.rs
@@ -1,8 +1,10 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    lookup_key::Key,
-    printing::{Action::*, BriefPrintableTask, PrintableWarning, Status::*},
+    todo_lookup_key::Key,
+    todo_printing::{
+        Action::*, BriefPrintableTask, PrintableWarning, Status::*,
+    },
 };
 
 #[test]

--- a/app/src/priority.rs
+++ b/app/src/priority.rs
@@ -1,8 +1,8 @@
 use {
     super::util::{format_task, lookup_tasks},
-    cli::Priority,
-    model::{TaskId, TaskSet, TaskStatus, TodoList},
-    printing::{PrintableAppSuccess, PrintableResult},
+    todo_cli::Priority,
+    todo_model::{TaskId, TaskSet, TaskStatus, TodoList},
+    todo_printing::{PrintableAppSuccess, PrintableResult},
 };
 
 fn set_priority<'list>(

--- a/app/src/priority_test.rs
+++ b/app/src/priority_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{Plicit::*, Status::*},
+    todo_printing::{Plicit::*, Status::*},
 };
 
 #[test]

--- a/app/src/punt.rs
+++ b/app/src/punt.rs
@@ -1,8 +1,8 @@
 use {
     super::util::{format_task, format_task_brief, lookup_tasks},
-    cli::Punt,
-    model::{PuntError, TaskSet, TodoList},
-    printing::{
+    todo_cli::Punt,
+    todo_model::{PuntError, TaskSet, TodoList},
+    todo_printing::{
         Action, PrintableAppSuccess, PrintableResult, PrintableWarning,
     },
 };

--- a/app/src/punt_test.rs
+++ b/app/src/punt_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, Status::*},
+    todo_printing::{Action::*, Status::*},
 };
 
 #[test]

--- a/app/src/put.rs
+++ b/app/src/put.rs
@@ -2,10 +2,12 @@ use {
     super::util::{
         format_task, format_task_brief, lookup_tasks, should_include_done,
     },
-    cli::Put,
-    model::{TaskId, TaskSet, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableError, PrintableResult},
     std::collections::HashSet,
+    todo_cli::Put,
+    todo_model::{TaskId, TaskSet, TodoList},
+    todo_printing::{
+        Action, PrintableAppSuccess, PrintableError, PrintableResult,
+    },
 };
 
 fn print_block_error(

--- a/app/src/put_test.rs
+++ b/app/src/put_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{
+    todo_printing::{
         Action::*, BriefPrintableTask, Plicit::*, PrintableError, Status::*,
     },
 };

--- a/app/src/restore.rs
+++ b/app/src/restore.rs
@@ -2,9 +2,9 @@ use {
     super::util::{
         format_task, format_task_brief, format_tasks_brief, lookup_tasks,
     },
-    cli::Restore,
-    model::{ForceRestored, RestoreError, TaskId, TaskSet, TodoList},
-    printing::{
+    todo_cli::Restore,
+    todo_model::{ForceRestored, RestoreError, TaskId, TaskSet, TodoList},
+    todo_printing::{
         Action, PrintableAppSuccess, PrintableError, PrintableResult,
         PrintableWarning,
     },

--- a/app/src/restore_test.rs
+++ b/app/src/restore_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{
+    todo_printing::{
         Action::*, BriefPrintableTask, PrintableError, PrintableWarning,
         Status::*,
     },

--- a/app/src/rm.rs
+++ b/app/src/rm.rs
@@ -1,8 +1,8 @@
 use {
     super::util::{format_task, lookup_tasks},
-    cli::Rm,
-    model::{TaskSet, TodoList},
-    printing::{PrintableAppSuccess, PrintableInfo, PrintableResult},
+    todo_cli::Rm,
+    todo_model::{TaskSet, TodoList},
+    todo_printing::{PrintableAppSuccess, PrintableInfo, PrintableResult},
 };
 
 pub fn run<'list>(

--- a/app/src/rm_test.rs
+++ b/app/src/rm_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{PrintableInfo, Status::*},
+    todo_printing::{PrintableInfo, Status::*},
 };
 
 fn info_removed(desc: &str) -> PrintableInfo {

--- a/app/src/snooze.rs
+++ b/app/src/snooze.rs
@@ -3,9 +3,9 @@ use {
         format_task, format_task_brief, lookup_tasks, parse_snooze_date,
     },
     chrono::{DateTime, Utc},
-    cli::Snooze,
-    model::{SnoozeWarning, TaskId, TaskSet, TodoList},
-    printing::{
+    todo_cli::Snooze,
+    todo_model::{SnoozeWarning, TaskId, TaskSet, TodoList},
+    todo_printing::{
         Action, PrintableAppSuccess, PrintableError, PrintableResult,
         PrintableWarning,
     },

--- a/app/src/snooze_test.rs
+++ b/app/src/snooze_test.rs
@@ -3,11 +3,11 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{
+    todo_printing::{
         Action::*, BriefPrintableTask, Plicit::Explicit, PrintableError,
         PrintableWarning, Status::*,
     },
-    testing::ymdhms,
+    todo_testing::ymdhms,
 };
 
 #[test]

--- a/app/src/snoozed.rs
+++ b/app/src/snoozed.rs
@@ -1,8 +1,8 @@
 use {
     super::util::format_task,
     chrono::{DateTime, Utc},
-    model::TodoList,
-    printing::{PrintableAppSuccess, PrintableResult},
+    todo_model::TodoList,
+    todo_printing::{PrintableAppSuccess, PrintableResult},
 };
 
 pub fn run<'list>(

--- a/app/src/snoozed_test.rs
+++ b/app/src/snoozed_test.rs
@@ -1,7 +1,7 @@
 #[allow(clippy::zero_prefixed_literal)]
 use {
-    super::testing::task, super::testing::Fixture, printing::Status::*,
-    testing::ymdhms,
+    super::testing::task, super::testing::Fixture, todo_printing::Status::*,
+    todo_testing::ymdhms,
 };
 
 #[test]

--- a/app/src/split.rs
+++ b/app/src/split.rs
@@ -2,10 +2,10 @@ use chrono::Duration;
 
 use {
     super::util::{format_task, lookup_tasks},
-    cli::Split,
-    model::{DurationInSeconds, NewOptions, TaskId, TaskSet, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableResult},
     std::borrow::Cow,
+    todo_cli::Split,
+    todo_model::{DurationInSeconds, NewOptions, TaskId, TaskSet, TodoList},
+    todo_printing::{Action, PrintableAppSuccess, PrintableResult},
 };
 
 #[derive(Default)]

--- a/app/src/split_test.rs
+++ b/app/src/split_test.rs
@@ -5,8 +5,8 @@ use chrono::Duration;
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, Status::*},
-    testing::ymdhms,
+    todo_printing::{Action::*, Status::*},
+    todo_testing::ymdhms,
 };
 
 #[test]

--- a/app/src/status.rs
+++ b/app/src/status.rs
@@ -1,8 +1,8 @@
 use {
     super::util::format_task,
     chrono::{DateTime, Utc},
-    model::{TaskStatus, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableResult},
+    todo_model::{TaskStatus, TodoList},
+    todo_printing::{Action, PrintableAppSuccess, PrintableResult},
 };
 
 pub struct Status {

--- a/app/src/status_test.rs
+++ b/app/src/status_test.rs
@@ -3,8 +3,8 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, Status::*},
-    testing::ymdhms,
+    todo_printing::{Action::*, Status::*},
+    todo_testing::ymdhms,
 };
 
 #[test]

--- a/app/src/tag.rs
+++ b/app/src/tag.rs
@@ -1,8 +1,8 @@
 use {
     super::util::{format_task, lookup_tasks},
-    cli::Tag,
-    model::{TaskSet, TaskStatus, TodoList},
-    printing::{Action, PrintableAppSuccess, PrintableResult},
+    todo_cli::Tag,
+    todo_model::{TaskSet, TaskStatus, TodoList},
+    todo_printing::{Action, PrintableAppSuccess, PrintableResult},
 };
 
 fn print_all_tags<'list>(

--- a/app/src/tag_test.rs
+++ b/app/src/tag_test.rs
@@ -1,7 +1,7 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, Status::*},
+    todo_printing::{Action::*, Status::*},
 };
 
 #[test]

--- a/app/src/testing.rs
+++ b/app/src/testing.rs
@@ -3,15 +3,15 @@
 use {
     chrono::{TimeZone, Utc},
     clap::Parser,
-    cli::Options,
-    clock::FakeClock,
-    model::TodoList,
     pretty_assertions::assert_eq,
-    printing::{
+    todo_cli::Options,
+    todo_clock::FakeClock,
+    todo_model::TodoList,
+    todo_printing::{
         PrintableError, PrintableInfo, PrintableTask, PrintableWarning, Status,
         TodoPrinter,
     },
-    text_editing::FakeTextEditor,
+    todo_text_editing::FakeTextEditor,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -141,7 +141,7 @@ impl<'list> Fixture<'list> {
         let args = shlex::split(s).expect("Could not split args");
         let options =
             Options::try_parse_from(args).expect("Could not parse args");
-        use printing::Printable;
+        use todo_printing::Printable;
         let mutated = crate::todo(
             &mut self.list,
             &self.text_editor,

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -4,11 +4,11 @@ use {
         new, path, priority, punt, put, restore, rm, snooze, snoozed, split,
         status, tag, top, unblock, unsnooze,
     },
-    cli::{Options, SubCommand},
-    clock::Clock,
-    model::TodoList,
-    printing::PrintableResult,
-    text_editing::TextEditor,
+    todo_cli::{Options, SubCommand},
+    todo_clock::Clock,
+    todo_model::TodoList,
+    todo_printing::PrintableResult,
+    todo_text_editing::TextEditor,
 };
 
 fn status_options(options: Options) -> status::Status {

--- a/app/src/top.rs
+++ b/app/src/top.rs
@@ -1,8 +1,8 @@
 use {
     super::util::{format_task, lookup_task, should_include_done},
-    cli::Top,
-    model::{TaskSet, TaskStatus, TodoList},
-    printing::{PrintableAppSuccess, PrintableResult, PrintableWarning},
+    todo_cli::Top,
+    todo_model::{TaskSet, TaskStatus, TodoList},
+    todo_printing::{PrintableAppSuccess, PrintableResult, PrintableWarning},
 };
 
 pub fn run<'list>(list: &'list TodoList, cmd: &Top) -> PrintableResult<'list> {

--- a/app/src/top_test.rs
+++ b/app/src/top_test.rs
@@ -1,8 +1,8 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    lookup_key::Key,
-    printing::{PrintableWarning, Status::*},
+    todo_lookup_key::Key,
+    todo_printing::{PrintableWarning, Status::*},
 };
 
 #[test]

--- a/app/src/unblock.rs
+++ b/app/src/unblock.rs
@@ -2,9 +2,9 @@ use {
     super::util::{
         format_task, format_task_brief, lookup_tasks, should_include_done,
     },
-    cli::Unblock,
-    model::{TaskSet, TodoList},
-    printing::{
+    todo_cli::Unblock,
+    todo_model::{TaskSet, TodoList},
+    todo_printing::{
         Action, PrintableAppSuccess, PrintableError, PrintableResult,
         PrintableWarning,
     },

--- a/app/src/unblock_test.rs
+++ b/app/src/unblock_test.rs
@@ -1,8 +1,8 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    lookup_key::Key,
-    printing::{
+    todo_lookup_key::Key,
+    todo_printing::{
         Action::*, BriefPrintableTask, Plicit::*, PrintableError,
         PrintableWarning, Status::*,
     },

--- a/app/src/unsnooze.rs
+++ b/app/src/unsnooze.rs
@@ -2,9 +2,9 @@ use {
     super::util::{
         format_task, format_task_brief, format_tasks_brief, lookup_tasks,
     },
-    cli::Unsnooze,
-    model::{TaskSet, TodoList, UnsnoozeWarning},
-    printing::{
+    todo_cli::Unsnooze,
+    todo_model::{TaskSet, TodoList, UnsnoozeWarning},
+    todo_printing::{
         Action, PrintableAppSuccess, PrintableResult, PrintableWarning,
     },
 };

--- a/app/src/unsnooze_test.rs
+++ b/app/src/unsnooze_test.rs
@@ -3,8 +3,10 @@
 use {
     super::testing::task,
     super::testing::Fixture,
-    printing::{Action::*, BriefPrintableTask, PrintableWarning, Status::*},
-    testing::ymdhms,
+    todo_printing::{
+        Action::*, BriefPrintableTask, PrintableWarning, Status::*,
+    },
+    todo_testing::ymdhms,
 };
 
 #[test]

--- a/app/src/util.rs
+++ b/app/src/util.rs
@@ -1,11 +1,11 @@
 use {
     chrono::{DateTime, Duration, Local, Utc},
-    lookup_key::Key,
-    model::{DurationInSeconds, TaskId, TaskSet, TaskStatus, TodoList},
-    printing::{
+    std::convert::TryFrom,
+    todo_lookup_key::Key,
+    todo_model::{DurationInSeconds, TaskId, TaskSet, TaskStatus, TodoList},
+    todo_printing::{
         BriefPrintableTask, Plicit, PrintableError, PrintableTask, Status,
     },
-    std::convert::TryFrom,
 };
 
 fn to_printing_status(status: TaskStatus) -> Status {
@@ -216,11 +216,11 @@ pub fn parse_due_date(
         return Ok(None);
     }
     let due_date_string = chunks.join(" ");
-    match ::time_format::parse_time(
+    match ::todo_time_format::parse_time(
         Local,
         now.with_timezone(&Local),
         &due_date_string,
-        ::time_format::Snap::ToEnd,
+        ::todo_time_format::Snap::ToEnd,
     ) {
         Ok(due_date) => Ok(Some(due_date.with_timezone(&Utc))),
         Err(_) => Err(PrintableError::CannotParseDueDate {
@@ -262,11 +262,11 @@ pub fn parse_snooze_date(
     if date_string.is_empty() || date_string.is_empty() {
         return Ok(None);
     }
-    match ::time_format::parse_time(
+    match ::todo_time_format::parse_time(
         Local,
         now.with_timezone(&Local),
         &date_string,
-        ::time_format::Snap::ToStart,
+        ::todo_time_format::Snap::ToStart,
     ) {
         Ok(snooze_date) => Ok(Some(snooze_date.with_timezone(&Utc))),
         Err(_) => Err(PrintableError::CannotParseDueDate {

--- a/app/src/util_test.rs
+++ b/app/src/util_test.rs
@@ -5,10 +5,10 @@ use {
     super::util::*,
     ::pretty_assertions::assert_eq,
     chrono::Duration,
-    lookup_key::Key,
-    model::{CheckOptions, NewOptions, TodoList},
-    printing::{Action::*, Plicit::*, Status::*},
-    testing::ymdhms,
+    todo_lookup_key::Key,
+    todo_model::{CheckOptions, NewOptions, TodoList},
+    todo_printing::{Action::*, Plicit::*, Status::*},
+    todo_testing::ymdhms,
 };
 
 #[test]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "cli"
+name = "todo_cli"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
 clap.workspace = true
 
-lookup_key.workspace = true
+todo_config.workspace = true
+todo_lookup_key.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = { version = "4.0.*", features = ["derive"] }
+clap.workspace = true
 
-lookup_key = { path = "../lookup_key" }
+lookup_key.workspace = true

--- a/cli/src/subcommands/block.rs
+++ b/cli/src/subcommands/block.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Block tasks on other tasks.
 ///

--- a/cli/src/subcommands/block_test.rs
+++ b/cli/src/subcommands/block_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Block, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/bottom.rs
+++ b/cli/src/subcommands/bottom.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Shows bottom-level tasks, i.e. tasks with no dependencies.
 ///

--- a/cli/src/subcommands/bottom_test.rs
+++ b/cli/src/subcommands/bottom_test.rs
@@ -1,6 +1,6 @@
 use {
     crate::{testing::expect_parses_into, Bottom, SubCommand},
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/budget.rs
+++ b/cli/src/subcommands/budget.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Assign a time budget to the given tasks.
 ///

--- a/cli/src/subcommands/budget_test.rs
+++ b/cli/src/subcommands/budget_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Budget, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/chain.rs
+++ b/cli/src/subcommands/chain.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Chain tasks in a blocking sequence.
 ///

--- a/cli/src/subcommands/chain_test.rs
+++ b/cli/src/subcommands/chain_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Chain, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/check.rs
+++ b/cli/src/subcommands/check.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Marks tasks as complete.
 ///

--- a/cli/src/subcommands/check_test.rs
+++ b/cli/src/subcommands/check_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Check, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/due.rs
+++ b/cli/src/subcommands/due.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Assigns or queries due dates.
 ///

--- a/cli/src/subcommands/due_test.rs
+++ b/cli/src/subcommands/due_test.rs
@@ -1,6 +1,6 @@
 use {
     crate::{testing::expect_parses_into, Due, SubCommand},
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/edit.rs
+++ b/cli/src/subcommands/edit.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Edit the description of tasks.
 ///

--- a/cli/src/subcommands/edit_test.rs
+++ b/cli/src/subcommands/edit_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Edit, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/get.rs
+++ b/cli/src/subcommands/get.rs
@@ -1,6 +1,6 @@
 use clap::ArgGroup;
 
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Shows tasks related to given tasks.
 ///

--- a/cli/src/subcommands/get_test.rs
+++ b/cli/src/subcommands/get_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Get, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/merge.rs
+++ b/cli/src/subcommands/merge.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Merges two or more tasks into one.
 ///

--- a/cli/src/subcommands/merge_test.rs
+++ b/cli/src/subcommands/merge_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Merge, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/new.rs
+++ b/cli/src/subcommands/new.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Creates new tasks in the to-do list.
 ///

--- a/cli/src/subcommands/new_test.rs
+++ b/cli/src/subcommands/new_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         New, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/path.rs
+++ b/cli/src/subcommands/path.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Show the dependency paths between two tasks.
 ///

--- a/cli/src/subcommands/path_test.rs
+++ b/cli/src/subcommands/path_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Path, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/priority.rs
+++ b/cli/src/subcommands/priority.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Assign or query priority levels.
 ///

--- a/cli/src/subcommands/priority_test.rs
+++ b/cli/src/subcommands/priority_test.rs
@@ -1,6 +1,6 @@
 use {
     crate::{testing::expect_parses_into, Priority, SubCommand},
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/punt.rs
+++ b/cli/src/subcommands/punt.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Punts tasks to the end of the list.
 ///

--- a/cli/src/subcommands/punt_test.rs
+++ b/cli/src/subcommands/punt_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Punt, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/put.rs
+++ b/cli/src/subcommands/put.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 #[derive(Debug, Default, PartialEq, Eq, Parser)]
 pub struct Prepositions {

--- a/cli/src/subcommands/put_test.rs
+++ b/cli/src/subcommands/put_test.rs
@@ -4,7 +4,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Put, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/restore.rs
+++ b/cli/src/subcommands/restore.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Restore completed tasks.
 ///

--- a/cli/src/subcommands/restore_test.rs
+++ b/cli/src/subcommands/restore_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Restore, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/rm.rs
+++ b/cli/src/subcommands/rm.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Removes tasks from the list permanently.
 ///

--- a/cli/src/subcommands/rm_test.rs
+++ b/cli/src/subcommands/rm_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Rm, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/snooze.rs
+++ b/cli/src/subcommands/snooze.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Makes tasks temporarily "snoozed" until the given amount of time passes.
 ///

--- a/cli/src/subcommands/snooze_test.rs
+++ b/cli/src/subcommands/snooze_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Snooze, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/split.rs
+++ b/cli/src/subcommands/split.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Turns a single task into multiple tasks.
 ///

--- a/cli/src/subcommands/split_test.rs
+++ b/cli/src/subcommands/split_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         Split, SubCommand,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/tag.rs
+++ b/cli/src/subcommands/tag.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Shows, marks, or unmarks tags.
 ///

--- a/cli/src/subcommands/tag_test.rs
+++ b/cli/src/subcommands/tag_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         SubCommand, Tag,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/top.rs
+++ b/cli/src/subcommands/top.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Shows top-level tasks, i.e. tasks with no antidependencies.
 ///

--- a/cli/src/subcommands/top_test.rs
+++ b/cli/src/subcommands/top_test.rs
@@ -1,6 +1,6 @@
 use {
     crate::{testing::expect_parses_into, SubCommand, Top},
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/unblock.rs
+++ b/cli/src/subcommands/unblock.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Unblock tasks from other tasks.
 ///

--- a/cli/src/subcommands/unblock_test.rs
+++ b/cli/src/subcommands/unblock_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         SubCommand, Unblock,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/cli/src/subcommands/unsnooze.rs
+++ b/cli/src/subcommands/unsnooze.rs
@@ -1,4 +1,4 @@
-use {clap::Parser, lookup_key::Key};
+use {clap::Parser, todo_lookup_key::Key};
 
 /// Unsnoozes snoozed tasks.
 ///

--- a/cli/src/subcommands/unsnooze_test.rs
+++ b/cli/src/subcommands/unsnooze_test.rs
@@ -3,7 +3,7 @@ use {
         testing::{expect_error, expect_parses_into},
         SubCommand, Unsnooze,
     },
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/clock/Cargo.toml
+++ b/clock/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "clock"
+name = "todo_clock"
 edition = "2021"
 version = "0.1.0"
 authors = ["Simeon <simeon.anfinrud@mac.com"]

--- a/clock/Cargo.toml
+++ b/clock/Cargo.toml
@@ -5,4 +5,4 @@ version = "0.1.0"
 authors = ["Simeon <simeon.anfinrud@mac.com"]
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
+chrono.workspace = true

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "1.0.30"
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "config"
+name = "todo_config"
 version = "0.1.0"
 edition = "2021"
 

--- a/lookup_key/Cargo.toml
+++ b/lookup_key/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lookup_key"
+name = "todo_lookup_key"
 version = "0.1.0"
 edition = "2021"
 

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "main"
+name = "todo_main"
 version = "0.1.0"
 edition = "2021"
 
@@ -10,10 +10,10 @@ serde_json.workspace = true
 term_size.workspace = true
 thiserror.workspace = true
 
-app.workspace = true
-cli.workspace = true
-clock.workspace = true
-config.workspace = true
-model.workspace = true
-printing.workspace = true
-text_editing.workspace = true
+todo_app.workspace = true
+todo_cli.workspace = true
+todo_clock.workspace = true
+todo_config.workspace = true
+todo_model.workspace = true
+todo_printing.workspace = true
+todo_text_editing.workspace = true

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -4,16 +4,16 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = "4.0.*"
-directories = "5.0"
-serde_json = "1.0"
-term_size = "0.3"
-thiserror = "1.0.30"
+clap.workspace = true
+directories.workspace = true
+serde_json.workspace = true
+term_size.workspace = true
+thiserror.workspace = true
 
-app = {path = "../app" }
-cli = { path = "../cli" }
-clock = { path = "../clock" }
-config = { path = "../config" }
-model = { path = "../model" }
-printing = { path = "../printing" }
-text_editing = { path = "../text_editing" }
+app.workspace = true
+cli.workspace = true
+clock.workspace = true
+config.workspace = true
+model.workspace = true
+printing.workspace = true
+text_editing.workspace = true

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -5,14 +5,15 @@ version = "0.1.0"
 authors = ["Simeon <simeon.anfinrud@mac.com"]
 
 [dependencies]
-bisection = "0.1"
-chrono = { version = "0.4", features = ["serde"] }
-daggy = { version = "0.8", features = ["serde-1", "stable_dag"] }
-itertools = "0.11"
-serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0.30"
+bisection.workspace = true
+chrono.workspace = true
+daggy.workspace = true
+itertools.workspace = true
+serde.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-pretty_assertions = "1.3.0"
-serde_json = "1.0"
-testing = { path = "../testing" }
+pretty_assertions.workspace = true
+serde_json.workspace = true
+
+testing.workspace = true

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "model"
+name = "todo_model"
 edition = "2021"
 version = "0.1.0"
 authors = ["Simeon <simeon.anfinrud@mac.com"]
@@ -16,4 +16,4 @@ thiserror.workspace = true
 pretty_assertions.workspace = true
 serde_json.workspace = true
 
-testing.workspace = true
+todo_testing.workspace = true

--- a/model/src/todo_list_test/remove_test.rs
+++ b/model/src/todo_list_test/remove_test.rs
@@ -76,7 +76,7 @@ fn implicit_priority_is_cleaned_up() {
 
 #[test]
 fn implicit_due_date_is_cleaned_up() {
-    use testing::ymdhms;
+    use todo_testing::ymdhms;
     let mut list = TodoList::default();
     let a = list.add("a");
     let b_due = ymdhms(2020, 1, 1, 0, 0, 0);

--- a/printing/Cargo.toml
+++ b/printing/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "printing"
+name = "todo_printing"
 version = "0.1.0"
 edition = "2021"
 
@@ -8,6 +8,6 @@ ansi_term.workspace = true
 chrono.workspace = true
 textwrap.workspace = true
 
-lookup_key.workspace = true
-time_format.workspace = true
-testing.workspace = true
+todo_lookup_key.workspace = true
+todo_time_format.workspace = true
+todo_testing.workspace = true

--- a/printing/Cargo.toml
+++ b/printing/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ansi_term = "0.12"
-chrono = { version = "0.4", features = ["serde"] }
-textwrap = "0.16.0"
+ansi_term.workspace = true
+chrono.workspace = true
+textwrap.workspace = true
 
-lookup_key = { path = "../lookup_key" }
-time_format = { path = "../time_format" }
-testing = { path = "../testing" }
+lookup_key.workspace = true
+time_format.workspace = true
+testing.workspace = true

--- a/printing/src/format_util.rs
+++ b/printing/src/format_util.rs
@@ -1,8 +1,8 @@
 use {
     crate::{BriefPrintableTask, Status},
     ansi_term::Color,
-    lookup_key::Key,
     std::fmt,
+    todo_lookup_key::Key,
 };
 
 pub fn format_key(key: &Key) -> impl fmt::Display + '_ {

--- a/printing/src/printable_error.rs
+++ b/printing/src/printable_error.rs
@@ -4,11 +4,11 @@ use {
         BriefPrintableTask,
     },
     ansi_term::Color,
-    lookup_key::Key,
     std::{
         fmt,
         fmt::{Display, Formatter},
     },
+    todo_lookup_key::Key,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/printing/src/printable_task_test.rs
+++ b/printing/src/printable_task_test.rs
@@ -6,7 +6,7 @@ use {
         SimpleTodoPrinter, Status::*, TodoPrinter,
     },
     chrono::{DateTime, Utc},
-    testing::ymdhms,
+    todo_testing::ymdhms,
 };
 
 fn make_printing_context() -> PrintingContext {

--- a/printing/src/printable_warning.rs
+++ b/printing/src/printable_warning.rs
@@ -5,11 +5,11 @@ use {
     },
     ansi_term::Color,
     chrono::{DateTime, Utc},
-    lookup_key::Key,
     std::{
         fmt,
         fmt::{Display, Formatter},
     },
+    todo_lookup_key::Key,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/printing/src/printable_warning_test.rs
+++ b/printing/src/printable_warning_test.rs
@@ -1,6 +1,6 @@
 use {
     crate::{BriefPrintableTask, PrintableWarning::*, Status::*},
-    lookup_key::Key::*,
+    todo_lookup_key::Key::*,
 };
 
 #[test]

--- a/printing/src/simple_todo_printer.rs
+++ b/printing/src/simple_todo_printer.rs
@@ -83,7 +83,9 @@ fn fmt_snooze_date(snooze_duration: Duration, out: &mut String) {
                 .bold()
                 .paint(format!(
                     "Snoozed for {}",
-                    ::time_format::format_duration_laconic(snooze_duration)
+                    ::todo_time_format::format_duration_laconic(
+                        snooze_duration
+                    )
                 ))
                 .to_string(),
         );
@@ -134,7 +136,7 @@ fn fmt_due_date(
     if implicit {
         style = style.italic();
     }
-    let desc = ::time_format::display_relative_time(
+    let desc = ::todo_time_format::display_relative_time(
         context.now.with_timezone(&Local),
         due_date.with_timezone(&Local),
     );
@@ -149,7 +151,7 @@ fn fmt_punctuality(punctuality: Duration, out: &mut String) {
         } else {
             (Color::Green.bold(), "early", -punctuality)
         };
-    let desc = ::time_format::format_duration_laconic(abs_punctuality);
+    let desc = ::todo_time_format::format_duration_laconic(abs_punctuality);
     out.push_str(&style.paint(format!("Done {} {}", desc, suffix)).to_string());
     out.push(' ');
 }

--- a/printing/src/simple_todo_printer_test.rs
+++ b/printing/src/simple_todo_printer_test.rs
@@ -6,9 +6,9 @@ use {
         PrintableWarning, PrintingContext, SimpleTodoPrinter, Status::*,
         TodoPrinter,
     },
-    lookup_key::Key,
     std::io::Write,
-    testing::ymdhms,
+    todo_lookup_key::Key,
+    todo_testing::ymdhms,
 };
 
 fn create_printer_to_vec() -> SimpleTodoPrinter<Vec<u8>> {

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "testing"
+name = "todo_testing"
 version = "0.1.0"
 edition = "2021"
 

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
+chrono.workspace = true

--- a/text_editing/Cargo.toml
+++ b/text_editing/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-scrawl = "2.0"
+scrawl.workspace = true

--- a/text_editing/Cargo.toml
+++ b/text_editing/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "text_editing"
+name = "todo_text_editing"
 version = "0.1.0"
 edition = "2021"
 

--- a/time_format/Cargo.toml
+++ b/time_format/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
-humantime = "2.1"
+chrono.workspace = true
+humantime.workspace = true

--- a/time_format/Cargo.toml
+++ b/time_format/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "time_format"
+name = "todo_time_format"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
This was previously blocked on the 'crates' VS Code extension releasing a version that accepts this syntax.

This also updates the crate names of all local crates to use the 'todo_' prefix for better namespacing.