### PR TITLE
Correctly sort unsnoozed tasks.

### DIFF
--- a/app/src/merge.rs
+++ b/app/src/merge.rs
@@ -69,8 +69,7 @@ pub fn run<'list>(
     let start_date = tasks_to_merge
         .iter_unsorted()
         .map(|id| list.get(id).unwrap().start_date)
-        .max()
-        .unwrap_or(now);
+        .max();
     let tag = match cmd.tag {
         Some(value) => value,
         None => tasks_to_merge

--- a/app/src/new.rs
+++ b/app/src/new.rs
@@ -20,8 +20,7 @@ pub fn run<'list>(
     let due_date = parse_due_date(now, &cmd.due).map_err(|e| vec![e])?;
     let budget = parse_budget(&cmd.budget).map_err(|e| vec![e])?;
     let snooze_date = parse_snooze_date(now, &cmd.snooze)
-        .map_err(|e| vec![e])?
-        .unwrap_or_default();
+        .map_err(|e| vec![e])?;
     let deps = lookup_tasks(list, &cmd.blocked_by);
     let adeps = lookup_tasks(list, &cmd.blocking);
     let before = lookup_tasks(list, &cmd.before);

--- a/app/src/split.rs
+++ b/app/src/split.rs
@@ -54,7 +54,7 @@ fn split(
                 } else {
                     task.budget
                 },
-                start_date: task.start_date,
+                start_date: Some(task.start_date),
                 tag: match tag {
                     Some(value) => value,
                     None => !keep && original_is_tag,

--- a/model/src/task.rs
+++ b/model/src/task.rs
@@ -47,7 +47,7 @@ pub struct NewOptions<'ser> {
     pub priority: i32,
     pub due_date: Option<DateTime<Utc>>,
     pub budget: DurationInSeconds,
-    pub start_date: DateTime<Utc>,
+    pub start_date: Option<DateTime<Utc>>,
     pub tag: bool,
 }
 
@@ -61,7 +61,7 @@ impl<'ser> NewOptions<'ser> {
             priority: 0,
             due_date: None,
             budget: DurationInSeconds::default(),
-            start_date: now,
+            start_date: None,
             tag: false,
         }
     }
@@ -92,7 +92,7 @@ impl<'ser> NewOptions<'ser> {
     }
 
     pub fn start_date(mut self, start_date: DateTime<Utc>) -> Self {
-        self.start_date = start_date;
+        self.start_date = Some(start_date);
         self
     }
 
@@ -111,7 +111,7 @@ impl<'ser, S: Into<Cow<'ser, str>>> From<S> for NewOptions<'ser> {
             priority: 0,
             due_date: None,
             budget: DurationInSeconds::default(),
-            start_date: now,
+            start_date: None,
             tag: false,
         }
     }
@@ -131,7 +131,7 @@ impl<'ser> Task<'ser> {
             due_date: options.due_date,
             implicit_due_date: options.due_date,
             budget: options.budget,
-            start_date: options.start_date,
+            start_date: options.start_date.unwrap_or(options.now),
             tag: options.tag,
             implicit_tags: vec![],
         }

--- a/model/src/todo_list.rs
+++ b/model/src/todo_list.rs
@@ -908,7 +908,13 @@ impl<'ser> TodoList<'ser> {
         }
         // Reset the start date to the creation time.
         task.start_date = task.creation_time;
-        self.update_depth(id);
+        self.punt(id).map_err(|e| {
+            // This is redundant but I'd rather not have a panicking code path
+            // by using unwrap().
+            vec![match e {
+                PuntError::TaskIsComplete => UnsnoozeWarning::TaskIsComplete,
+            }]
+        })?;
         Ok(())
     }
 }


### PR DESCRIPTION
Snoozed tasks used to be put into a higher layer, so unsnoozing them
warranted a call to update_depth(). But now snoozed tasks are kept in
the same layer but kept sorted after all unsnoozed tasks in that layer,
so instead of updating the depth, we should update the sort order.

In the process of debugging this, I changed the defaults for task start
times when using NewOptions, which would confuse logic that checks
whether a task is snoozed by comparing the start time and creation time.

Finally, a test case that had an accurate comment describing the desired
sorted order, but had an incorrect assertion in code, has been fixed.