### PR TITLE
Add --until argument for 'snoozed' command.

### DIFF
--- a/app/src/new.rs
+++ b/app/src/new.rs
@@ -19,8 +19,8 @@ pub fn run<'list>(
 ) -> PrintableResult<'list> {
     let due_date = parse_due_date(now, &cmd.due).map_err(|e| vec![e])?;
     let budget = parse_budget(&cmd.budget).map_err(|e| vec![e])?;
-    let snooze_date = parse_snooze_date(now, &cmd.snooze)
-        .map_err(|e| vec![e])?;
+    let snooze_date =
+        parse_snooze_date(now, &cmd.snooze).map_err(|e| vec![e])?;
     let deps = lookup_tasks(list, &cmd.blocked_by);
     let adeps = lookup_tasks(list, &cmd.blocking);
     let before = lookup_tasks(list, &cmd.before);

--- a/app/src/snoozed.rs
+++ b/app/src/snoozed.rs
@@ -1,6 +1,9 @@
+use crate::util::parse_due_date;
+
 use {
     super::util::format_task,
     chrono::{DateTime, Utc},
+    todo_cli::Snoozed,
     todo_model::TodoList,
     todo_printing::{PrintableAppSuccess, PrintableResult},
 };
@@ -8,13 +11,21 @@ use {
 pub fn run<'list>(
     list: &'list TodoList,
     now: DateTime<Utc>,
+    cmd: &Snoozed,
 ) -> PrintableResult<'list> {
+    let until = match &cmd.until {
+        Some(chunks) => parse_due_date(now, chunks).map_err(|e| vec![e])?,
+        None => None,
+    };
     Ok(PrintableAppSuccess {
         tasks: list
             .all_tasks()
             .filter(|&id| {
                 list.get(id)
-                    .map(|task| task.start_date > now)
+                    .map(|task| task.start_date > now && (match until {
+                        Some(limit) => task.start_date <= limit,
+                        None => true,
+                    }))
                     .unwrap_or_else(|| false)
             })
             .map(|id| format_task(list, id))

--- a/app/src/snoozed_test.rs
+++ b/app/src/snoozed_test.rs
@@ -45,3 +45,46 @@ fn multiple_snoozed_tasks() {
         )
         .end();
 }
+
+#[test]
+fn snoozed_until_today() {
+    let mut fix = Fixture::default();
+    fix.clock.now = ymdhms(2023, 10, 14, 12, 00, 00);
+    fix.test("todo new a b c");
+    fix.test("todo snooze a --until 5pm");
+    fix.test("todo snooze b --until 10pm");
+    fix.test("todo snooze c --until tomorrow");
+    fix.test("todo snoozed --until today")
+        .modified(false)
+        .validate()
+        .printed_task(
+            &task("a", 1, Blocked).start_date(ymdhms(2023, 10, 14, 17, 00, 00)),
+        )
+        .printed_task(
+            &task("b", 2, Blocked).start_date(ymdhms(2023, 10, 14, 22, 00, 00)),
+        )
+        .end();
+}
+
+#[test]
+fn snoozed_until_tomorrow() {
+    let mut fix = Fixture::default();
+    fix.clock.now = ymdhms(2023, 10, 14, 12, 00, 00);
+    fix.test("todo new a b c");
+    fix.test("todo snooze a --until 5pm");
+    fix.test("todo snooze b --until 10pm");
+    fix.test("todo snooze c --until tomorrow");
+    fix.test("todo snoozed --until tomorrow")
+        .modified(false)
+        .validate()
+        .printed_task(
+            &task("a", 1, Blocked).start_date(ymdhms(2023, 10, 14, 17, 00, 00)),
+        )
+        .printed_task(
+            &task("b", 2, Blocked).start_date(ymdhms(2023, 10, 14, 22, 00, 00)),
+        )
+        .printed_task(
+            &task("c", 3, Blocked).start_date(ymdhms(2023, 10, 15, 00, 00, 00))
+        )
+        .end();
+}

--- a/app/src/todo.rs
+++ b/app/src/todo.rs
@@ -49,7 +49,7 @@ pub fn todo<'list>(
         Some(Restore(cmd)) => restore::run(list, &cmd),
         Some(Rm(cmd)) => rm::run(list, cmd),
         Some(Snooze(cmd)) => snooze::run(list, now, &cmd),
-        Some(Snoozed(_)) => snoozed::run(list, now),
+        Some(Snoozed(cmd)) => snoozed::run(list, now, &cmd),
         Some(Split(cmd)) => split::run(list, cmd),
         Some(Tag(cmd)) => tag::run(list, &cmd),
         Some(Top(cmd)) => top::run(list, &cmd),

--- a/cli/src/subcommands/snoozed.rs
+++ b/cli/src/subcommands/snoozed.rs
@@ -1,6 +1,13 @@
 use clap::Parser;
 
 /// Shows snoozed tasks.
-#[derive(Debug, PartialEq, Eq, Parser)]
+#[derive(Debug, Default, PartialEq, Eq, Parser)]
 #[command(verbatim_doc_comment)]
-pub struct Snoozed {}
+pub struct Snoozed {
+    /// Only show tasks that will unsnooze before the given time.
+    ///
+    /// This is a human-readable description of a date or time, like "5pm" or
+    /// "tomorrow".
+    #[arg(long, num_args = 1..)]
+    pub until: Option<Vec<String>>,
+}

--- a/cli/src/subcommands/snoozed_test.rs
+++ b/cli/src/subcommands/snoozed_test.rs
@@ -6,9 +6,35 @@ use crate::{
 #[test]
 fn snoozed_extraneous() {
     expect_error("todo snoozed foo");
+    expect_error("todo snoozed --until");
 }
 
 #[test]
 fn snoozed_no_args() {
-    expect_parses_into("todo snoozed", SubCommand::Snoozed(Snoozed {}));
+    expect_parses_into(
+        "todo snoozed",
+        SubCommand::Snoozed(Snoozed {
+            ..Default::default()
+        }),
+    );
+}
+
+#[test]
+fn snoozed_until_tomorrow() {
+    expect_parses_into(
+        "todo snoozed --until tomorrow",
+        SubCommand::Snoozed(Snoozed {
+            until: Some(vec!["tomorrow".to_string()]),
+        }),
+    );
+}
+
+#[test]
+fn snoozed_until_5_days() {
+    expect_parses_into(
+        "todo snoozed --until 5 days",
+        SubCommand::Snoozed(Snoozed {
+            until: Some(vec!["5".to_string(), "days".to_string()]),
+        }),
+    )
 }


### PR DESCRIPTION
This allows you to filter snoozed tasks by a threshold date. Useful for
seeing what will unsnooze tomorrow or some other date.