### PR TITLE
Generate HTML code coverage report in gitpod init.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 **/*.code-workspace
 **/*.profraw
 **/lcov.info
+**/tarpaulin-report.html

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ tasks:
   - init: |
       rustup component add llvm-tools-preview
       cargo install cargo-nextest cargo-tarpaulin bacon bat fd-find tere grcov
-      cargo tarpaulin --engine llvm -o lcov
+      cargo tarpaulin --engine llvm -o lcov html
       cargo build
     command: bacon test
 
@@ -14,7 +14,6 @@ vscode:
   extensions:
     - rust-lang.rust-analyzer
     - GitHub.copilot
-    - withfig.fig
     - serayuzgur.crates
     - ryanluker.vscode-coverage-gutters
     - tamasfe.even-better-toml


### PR DESCRIPTION
Now we will get both an lcov.info report that is legible to the
coverage-gutters extension and an HTML report that can be loaded in a
live preview and browsed in the IDE.

Simply re-run the `cargo tarpaulin` command from the .gitpod.yml file to
regenerate the reports.