### PR TITLE
Fix todo-update.

### DIFF
--- a/todo-update
+++ b/todo-update
@@ -2,6 +2,6 @@
 
 BIN_DIR=/usr/local/bin/todo
 cargo build --release && \
-    cp target/release/main $BIN_DIR && \
+    cp target/release/todo_main $BIN_DIR && \
     echo "Successfully pushed new binary to $BIN_DIR" &&
     todo --version


### PR DESCRIPTION
Since renaming the modules to use the "todo_" namespace, the name of the
output binary has changed, so the script that installs the binary also
needs to be updated.