### PR TITLE
Do not split URLs.

### DIFF
--- a/printing/src/simple_todo_printer.rs
+++ b/printing/src/simple_todo_printer.rs
@@ -286,6 +286,7 @@ impl<'a> Display for PrintableTaskWithContext<'a> {
             textwrap::Options::new(self.context.width)
                 .initial_indent(&start)
                 .break_words(false)
+                .word_separator(textwrap::WordSeparator::AsciiSpace)
                 .subsequent_indent(&subsequent_indent),
         ))
     }

--- a/printing/src/tests/printable_task_test.rs
+++ b/printing/src/tests/printable_task_test.rs
@@ -621,3 +621,27 @@ fn explicit_tag_with_implicit_tags_and_punctuality() {
         )
     );
 }
+
+#[test]
+fn do_not_split_url() {
+    let context = PrintingContext {
+        max_index_digits: 3,
+        width: 40,
+        now: Utc::now(),
+    };
+    let fmt = print_task_with_context(
+        context,
+        &PrintableTask::new(
+            "http://example.com/this/is/a/long/url/that/should/not/be/split",
+            1,
+            Incomplete,
+        ),
+    );
+    assert_eq!(
+        fmt,
+        concat!(
+            "      \u{1b}[33m1)\u{1b}[0m ",
+            "http://example.com/this/is/a/long/url/that/should/not/be/split\n"
+        )
+    );
+}


### PR DESCRIPTION
By using the AsciiSpace WordSeparator, words are split at spaces and
not at hyphens or slashes, which means URLs with these characters
are not split.