### PR TITLE
Smart handling for ambiguous keys in 'get'.

### DIFF
--- a/builtin_apps/src/tests/get_test.rs
+++ b/builtin_apps/src/tests/get_test.rs
@@ -192,7 +192,6 @@ fn get_no_context_complete_and_incomplete_match() {
     fix.test("todo get a -n")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", 0, Complete).action(Select))
         .printed_task(&task("a", 2, Blocked).action(Select).deps_stats(1, 2))
         .end();
 }
@@ -246,5 +245,94 @@ fn get_blocking_shows_transitive_deps() {
         .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
         .printed_task(&task("c", 3, Blocked).deps_stats(1, 2))
         .printed_task(&task("d", 4, Blocked).action(Select).deps_stats(1, 3))
+        .end();
+}
+
+#[test]
+fn ambiguous_key_with_mixed_matches_only_shows_incomplete_matches() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a a");
+    fix.test("todo check 1");
+    fix.test("todo get a")
+        .modified(Mutated::No)
+        .validate()
+        .printed_task(&task("a", 1, Incomplete).action(Select))
+        .end();
+}
+
+#[test]
+fn ambiguous_key_with_only_incomplete_matches_shows_all_matches() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a a");
+    fix.test("todo get a")
+        .modified(Mutated::No)
+        .validate()
+        .printed_task(&task("a", 1, Incomplete).action(Select))
+        .printed_task(&task("a", 2, Incomplete).action(Select))
+        .end();
+}
+
+#[test]
+fn ambiguous_key_with_only_complete_matches_shows_all_matches() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a a");
+    fix.test("todo check 1 2");
+    fix.test("todo get a")
+        .modified(Mutated::No)
+        .validate()
+        .printed_task(&task("a", -1, Complete).action(Select))
+        .printed_task(&task("a", 0, Complete).action(Select))
+        .end();
+}
+
+#[test]
+fn multiple_ambiguous_keys_with_mixed_matches_only_shows_incomplete_matches() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a a b b");
+    fix.test("todo check 1 3");
+    fix.test("todo get a b")
+        .modified(Mutated::No)
+        .validate()
+        .printed_task(&task("a", 1, Incomplete).action(Select))
+        .printed_task(&task("b", 2, Incomplete).action(Select))
+        .end();
+}
+
+#[test]
+fn one_ambiguous_key_with_mixed_matches_and_one_without_mixed_matches() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a a b");
+    fix.test("todo check 1");
+    fix.test("todo get a b")
+        .modified(Mutated::No)
+        .validate()
+        .printed_task(&task("a", 1, Incomplete).action(Select))
+        .printed_task(&task("b", 2, Incomplete).action(Select))
+        .end();
+}
+
+#[test]
+fn one_key_that_is_only_complete_and_one_that_is_only_incomplete() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b");
+    fix.test("todo check 1");
+    fix.test("todo get a b")
+        .modified(Mutated::No)
+        .validate()
+        .printed_task(&task("a", 0, Complete).action(Select))
+        .printed_task(&task("b", 1, Incomplete).action(Select))
+        .end();
+}
+
+#[test]
+fn show_complete_ambiguous_tasks_when_requested() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a a");
+    fix.test("todo check 1");
+    fix.test("todo get a -d")
+        .modified(Mutated::No)
+        .validate()
+        .printed_task(&task("a", 0, Complete).action(Select))
+        .printed_task(&task("a", 1, Incomplete).action(Select))
         .end();
 }

--- a/builtin_apps/src/util.rs
+++ b/builtin_apps/src/util.rs
@@ -7,6 +7,7 @@ use {
         BriefPrintableTask, Plicit, PrintableError, PrintableTask, Status,
     },
 };
+use std::collections::HashMap;
 
 fn to_printing_status(status: TaskStatus) -> Status {
     match status {
@@ -191,6 +192,13 @@ pub fn lookup_tasks<'a>(
     keys.into_iter().fold(TaskSet::default(), |so_far, key| {
         so_far | lookup_task(list, key)
     })
+}
+
+pub fn lookup_tasks_by_keys<'a>(
+    list: &'a TodoList,
+    keys: impl IntoIterator<Item = &'a Key>,
+) -> HashMap<&'a Key, TaskSet> {
+    keys.into_iter().map(|key| (key, lookup_task(list, key))).collect()
 }
 
 fn any_tasks_are_complete(

--- a/lookup_key/src/lib.rs
+++ b/lookup_key/src/lib.rs
@@ -1,6 +1,6 @@
 use std::{num::ParseIntError, str::FromStr};
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub enum Key {
     ByNumber(i32),
     ByName(String),

--- a/model/src/task_set.rs
+++ b/model/src/task_set.rs
@@ -85,12 +85,16 @@ impl TaskSet {
         if include_done {
             self
         } else {
-            TaskSet {
-                ids: HashSet::from_iter(self.ids.into_iter().filter(|&id| {
-                    list.status(id) != Some(TaskStatus::Complete)
-                })),
-            }
+            self.partition_done(list).1
         }
+    }
+
+    pub fn partition_done(self, list: &TodoList) -> (Self, Self) {
+        let (done, not_done): (HashSet<_>, HashSet<_>) = self
+            .ids
+            .into_iter()
+            .partition(|&id| list.status(id) == Some(TaskStatus::Complete));
+        (Self { ids: done }, Self { ids: not_done })
     }
 
     pub fn as_sorted_vec(&self, list: &TodoList) -> Vec<TaskId> {


### PR DESCRIPTION
If there are complete and incomplete matches for a key, by default only the incomplete matches are shown. If all matches are complete, then they are all shown.

If you want to show all matches, complete or incomplete, you can use the '-d' option as before.