### PR TITLE
Truncate-tags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.0.*", features = ["derive"] }
 daggy = { version = "0.8", features = ["serde-1", "stable_dag"] }
 directories = "5.0"
+either = "1.11"
 humantime = "2.1"
 itertools = "0.12"
 pretty_assertions = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ daggy = { version = "0.8", features = ["serde-1", "stable_dag"] }
 directories = "5.0"
 either = "1.11"
 humantime = "2.1"
-itertools = "0.12"
+itertools = "0.13"
 pretty_assertions = "1.1"
 scrawl = "2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/builtin_apps/src/get.rs
+++ b/builtin_apps/src/get.rs
@@ -74,11 +74,12 @@ pub fn run<'list>(list: &'list TodoList, cmd: &Get) -> PrintableResult<'list> {
         .include_done(list, include_done)
         .iter_sorted(list)
         .map(|id| {
-            format_task(list, id).action(if requested_tasks.contains(id) {
-                Action::Select
+            let task = format_task(list, id);
+            if requested_tasks.contains(id) {
+                task.action(Action::Select).truncate_tags_if_needed(false)
             } else {
-                Action::None
-            })
+                task.action(Action::None)
+            }
         })
         .collect();
     Ok(PrintableAppSuccess {

--- a/builtin_apps/src/get.rs
+++ b/builtin_apps/src/get.rs
@@ -54,6 +54,8 @@ pub fn run<'list>(list: &'list TodoList, cmd: &Get) -> PrintableResult<'list> {
             // By default, show all context.
             (false, false, false) => (true, true),
             // Any other combination is invalid.
+            // TODO: we will be able to avoid this unreachable!() once
+            // https://github.com/clap-rs/clap/issues/2621 is resolved.
             _ => unreachable!(),
         };
     let tasks_to_print = requested_tasks

--- a/builtin_apps/src/log.rs
+++ b/builtin_apps/src/log.rs
@@ -23,7 +23,7 @@ pub fn run<'list>(list: &'list TodoList) -> PrintableResult<'list> {
                     },
                 );
                 formatted_task.log_date(if to_show != most_recent_shown {
-                    most_recent_shown = to_show.clone();
+                    most_recent_shown.clone_from(&to_show);
                     to_show.unwrap()
                 } else {
                     LogDate::Invisible

--- a/builtin_apps/src/tests/edit_test.rs
+++ b/builtin_apps/src/tests/edit_test.rs
@@ -117,6 +117,7 @@ fn edit_with_text_editor_empty_description() {
         .validate()
         .printed_error(&PrintableError::CannotEditBecauseInvalidLine {
             malformed_line: "1)".to_string(),
+            explanation: "Missing task description".to_string(),
         })
         .end();
     assert_eq!(*fix.text_editor.recorded_input(), prompt_with("1) a"));
@@ -132,6 +133,7 @@ fn edit_with_text_editor_empty_description_with_trailing_whitespace() {
         .validate()
         .printed_error(&PrintableError::CannotEditBecauseInvalidLine {
             malformed_line: "1) ".to_string(),
+            explanation: "Missing task description".to_string(),
         })
         .end();
     assert_eq!(*fix.text_editor.recorded_input(), prompt_with("1) a"));
@@ -147,6 +149,8 @@ fn edit_with_text_editor_remove_delimiter() {
         .validate()
         .printed_error(&PrintableError::CannotEditBecauseInvalidLine {
             malformed_line: "1 b".to_string(),
+            explanation: "Missing ')' delimiter between number and description"
+                .to_string(),
         })
         .end();
     assert_eq!(*fix.text_editor.recorded_input(), prompt_with("1) a"));
@@ -162,6 +166,8 @@ fn edit_with_text_editor_remove_delimiter_including_whitespace() {
         .validate()
         .printed_error(&PrintableError::CannotEditBecauseInvalidLine {
             malformed_line: "1b".to_string(),
+            explanation: "Missing ')' delimiter between number and description"
+                .to_string(),
         })
         .end();
     assert_eq!(*fix.text_editor.recorded_input(), prompt_with("1) a"));

--- a/builtin_apps/src/tests/get_test.rs
+++ b/builtin_apps/src/tests/get_test.rs
@@ -12,7 +12,11 @@ fn get_incomplete_task() {
     fix.test("todo get 2")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("b", 2, Incomplete).action(Select))
+        .printed_task(
+            &task("b", 2, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -24,7 +28,11 @@ fn get_complete_task() {
     fix.test("todo get -2")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", -2, Complete).action(Select))
+        .printed_task(
+            &task("a", -2, Complete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -35,9 +43,21 @@ fn get_multiple_tasks() {
     fix.test("todo get 2 3 4")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("b", 2, Incomplete).action(Select))
-        .printed_task(&task("c", 3, Incomplete).action(Select))
-        .printed_task(&task("d", 4, Incomplete).action(Select))
+        .printed_task(
+            &task("b", 2, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
+        .printed_task(
+            &task("c", 3, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
+        .printed_task(
+            &task("d", 4, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -49,7 +69,11 @@ fn get_excludes_completed_deps() {
     fix.test("todo get b")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("b", 1, Incomplete).action(Select))
+        .printed_task(
+            &task("b", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -62,7 +86,11 @@ fn get_include_done() {
         .modified(Mutated::No)
         .validate()
         .printed_task(&task("a", 0, Complete))
-        .printed_task(&task("b", 1, Incomplete).action(Select))
+        .printed_task(
+            &task("b", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -75,7 +103,12 @@ fn get_shows_blocking_tasks() {
         .modified(Mutated::No)
         .validate()
         .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 1))
-        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
+        .printed_task(
+            &task("b", 2, Blocked)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -88,7 +121,10 @@ fn get_shows_blocked_tasks() {
         .modified(Mutated::No)
         .validate()
         .printed_task(
-            &task("a", 1, Incomplete).action(Select).adeps_stats(1, 1),
+            &task("a", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .adeps_stats(1, 1),
         )
         .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
         .end();
@@ -103,7 +139,12 @@ fn get_shows_transitive_deps_and_adeps() {
         .validate()
         .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 4))
         .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
-        .printed_task(&task("c", 3, Blocked).action(Select).deps_stats(1, 2))
+        .printed_task(
+            &task("c", 3, Blocked)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .deps_stats(1, 2),
+        )
         .printed_task(&task("d", 4, Blocked).deps_stats(1, 3))
         .printed_task(&task("e", 5, Blocked).deps_stats(1, 4))
         .end();
@@ -116,8 +157,16 @@ fn get_by_name_multiple_matches() {
     fix.test("todo get bob")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("bob", 1, Incomplete).action(Select))
-        .printed_task(&task("bob", 3, Incomplete).action(Select))
+        .printed_task(
+            &task("bob", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
+        .printed_task(
+            &task("bob", 3, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -129,7 +178,10 @@ fn get_no_context_single_task_by_name() {
         .modified(Mutated::No)
         .validate()
         .printed_task(
-            &task("a", 1, Incomplete).action(Select).adeps_stats(1, 2),
+            &task("a", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .adeps_stats(1, 2),
         )
         .end();
 }
@@ -142,9 +194,17 @@ fn get_no_context_multiple_tasks_by_name() {
         .modified(Mutated::No)
         .validate()
         .printed_task(
-            &task("a", 1, Incomplete).action(Select).adeps_stats(1, 2),
+            &task("a", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .adeps_stats(1, 2),
         )
-        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
+        .printed_task(
+            &task("b", 2, Blocked)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -156,7 +216,11 @@ fn get_no_context_single_completed_task() {
     fix.test("todo get a -n")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", -2, Complete).action(Select))
+        .printed_task(
+            &task("a", -2, Complete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -168,8 +232,16 @@ fn get_no_context_multiple_completed_tasks() {
     fix.test("todo get a b -n")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", -2, Complete).action(Select))
-        .printed_task(&task("b", -1, Complete).action(Select))
+        .printed_task(
+            &task("a", -2, Complete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
+        .printed_task(
+            &task("b", -1, Complete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -180,7 +252,12 @@ fn get_no_context_blocked_task() {
     fix.test("todo get c -n")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("c", 3, Blocked).action(Select).deps_stats(1, 2))
+        .printed_task(
+            &task("c", 3, Blocked)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -192,7 +269,12 @@ fn get_no_context_complete_and_incomplete_match() {
     fix.test("todo get a -n")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", 2, Blocked).action(Select).deps_stats(1, 2))
+        .printed_task(
+            &task("a", 2, Blocked)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .deps_stats(1, 2),
+        )
         .end();
 }
 
@@ -203,7 +285,12 @@ fn get_blocked_by_one_task() {
     fix.test("todo get --blocked-by b")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
+        .printed_task(
+            &task("b", 2, Blocked)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .deps_stats(1, 1),
+        )
         .printed_task(&task("c", 3, Blocked).deps_stats(1, 2))
         .end();
 }
@@ -215,7 +302,12 @@ fn get_blocked_by_shows_transitive_adeps() {
     fix.test("todo get --blocked-by b")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
+        .printed_task(
+            &task("b", 2, Blocked)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .deps_stats(1, 1),
+        )
         .printed_task(&task("c", 3, Blocked).deps_stats(1, 2))
         .printed_task(&task("d", 4, Blocked).deps_stats(1, 3))
         .printed_task(&task("e", 5, Blocked).deps_stats(1, 4))
@@ -230,7 +322,12 @@ fn get_blocking_one_task() {
         .modified(Mutated::No)
         .validate()
         .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 2))
-        .printed_task(&task("b", 2, Blocked).action(Select).deps_stats(1, 1))
+        .printed_task(
+            &task("b", 2, Blocked)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .deps_stats(1, 1),
+        )
         .end();
 }
 
@@ -244,7 +341,12 @@ fn get_blocking_shows_transitive_deps() {
         .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 4))
         .printed_task(&task("b", 2, Blocked).deps_stats(1, 1))
         .printed_task(&task("c", 3, Blocked).deps_stats(1, 2))
-        .printed_task(&task("d", 4, Blocked).action(Select).deps_stats(1, 3))
+        .printed_task(
+            &task("d", 4, Blocked)
+                .action(Select)
+                .truncate_tags_if_needed(false)
+                .deps_stats(1, 3),
+        )
         .end();
 }
 
@@ -256,7 +358,11 @@ fn ambiguous_key_with_mixed_matches_only_shows_incomplete_matches() {
     fix.test("todo get a")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", 1, Incomplete).action(Select))
+        .printed_task(
+            &task("a", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -267,8 +373,16 @@ fn ambiguous_key_with_only_incomplete_matches_shows_all_matches() {
     fix.test("todo get a")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", 1, Incomplete).action(Select))
-        .printed_task(&task("a", 2, Incomplete).action(Select))
+        .printed_task(
+            &task("a", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
+        .printed_task(
+            &task("a", 2, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -280,8 +394,16 @@ fn ambiguous_key_with_only_complete_matches_shows_all_matches() {
     fix.test("todo get a")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", -1, Complete).action(Select))
-        .printed_task(&task("a", 0, Complete).action(Select))
+        .printed_task(
+            &task("a", -1, Complete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
+        .printed_task(
+            &task("a", 0, Complete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -293,8 +415,16 @@ fn multiple_ambiguous_keys_with_mixed_matches_only_shows_incomplete_matches() {
     fix.test("todo get a b")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", 1, Incomplete).action(Select))
-        .printed_task(&task("b", 2, Incomplete).action(Select))
+        .printed_task(
+            &task("a", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
+        .printed_task(
+            &task("b", 2, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -306,8 +436,16 @@ fn one_ambiguous_key_with_mixed_matches_and_one_without_mixed_matches() {
     fix.test("todo get a b")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", 1, Incomplete).action(Select))
-        .printed_task(&task("b", 2, Incomplete).action(Select))
+        .printed_task(
+            &task("a", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
+        .printed_task(
+            &task("b", 2, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -319,8 +457,16 @@ fn one_key_that_is_only_complete_and_one_that_is_only_incomplete() {
     fix.test("todo get a b")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", 0, Complete).action(Select))
-        .printed_task(&task("b", 1, Incomplete).action(Select))
+        .printed_task(
+            &task("a", 0, Complete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
+        .printed_task(
+            &task("b", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }
 
@@ -332,7 +478,15 @@ fn show_complete_ambiguous_tasks_when_requested() {
     fix.test("todo get a -d")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", 0, Complete).action(Select))
-        .printed_task(&task("a", 1, Incomplete).action(Select))
+        .printed_task(
+            &task("a", 0, Complete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
+        .printed_task(
+            &task("a", 1, Incomplete)
+                .action(Select)
+                .truncate_tags_if_needed(false),
+        )
         .end();
 }

--- a/builtin_apps/src/tests/new_test.rs
+++ b/builtin_apps/src/tests/new_test.rs
@@ -799,3 +799,211 @@ fn do_not_change_position_of_adep_if_complete() {
         .printed_task(&task("y", 1, Incomplete))
         .end();
 }
+
+#[test]
+fn block_on_task_by_name_that_matches_only_complete_tasks_blocks_that_task() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --done");
+    fix.test("todo new b -b a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("b", 1, Incomplete).action(New).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
+        .end();
+}
+
+#[test]
+fn block_on_task_by_name_that_matches_incomplete_and_complete_tasks() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --done");
+    fix.test("todo new a");
+    fix.test("todo new b --blocking a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("b", 1, Incomplete).action(New).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
+        .end();
+}
+
+#[test]
+fn block_on_task_by_name_that_matches_multiple_incomplete_tasks_blocks_on_all()
+{
+    let mut fix = Fixture::default();
+    fix.test("todo new a a");
+    fix.test("todo new b --blocking a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("b", 1, Incomplete).action(New).adeps_stats(2, 2))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("a", 3, Blocked).deps_stats(1, 1))
+        .end();
+}
+
+#[test]
+fn blocked_by_task_by_name_that_matches_only_complete_tasks_blocked_by_that_task(
+) {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --done");
+    fix.test("todo new b -p a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("a", 0, Complete))
+        .printed_task(&task("b", 1, Incomplete).action(New))
+        .end();
+}
+
+#[test]
+fn blocked_by_task_by_name_that_matches_incomplete_and_complete_tasks() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --done");
+    fix.test("todo new a");
+    fix.test("todo new b -p a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("b", 2, Blocked).action(New).deps_stats(1, 1))
+        .end();
+}
+
+#[test]
+fn blocked_by_task_by_name_that_matches_multiple_incomplete_tasks_blocked_by_all(
+) {
+    let mut fix = Fixture::default();
+    fix.test("todo new a a");
+    fix.test("todo new b -p a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("a", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("b", 3, Blocked).deps_stats(2, 2).action(New))
+        .end();
+}
+
+#[test]
+fn before_task_by_name_that_matches_only_complete_tasks_inserted_before_that_task(
+) {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --done");
+    fix.test("todo new b --before a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("b", 1, Incomplete).action(New).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
+        .end();
+}
+
+#[test]
+fn before_task_by_name_that_matches_incomplete_and_complete_tasks_inserted_before_all_tasks(
+) {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --done");
+    fix.test("todo new a");
+    fix.test("todo new b --before a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("b", 1, Incomplete).action(New).adeps_stats(1, 1))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
+        .end();
+}
+
+#[test]
+fn before_task_by_name_that_matches_multiple_incomplete_tasks_inserted_before_all_tasks(
+) {
+    let mut fix = Fixture::default();
+    fix.test("todo new a a");
+    fix.test("todo new b --before a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("b", 1, Incomplete).action(New).adeps_stats(2, 2))
+        .printed_task(&task("a", 2, Blocked).deps_stats(1, 1))
+        .printed_task(&task("a", 3, Blocked).deps_stats(1, 1))
+        .end();
+}
+
+#[test]
+fn after_task_by_name_that_matches_only_complete_tasks_inserted_after_that_task(
+) {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --done");
+    fix.test("todo new b --after a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("a", 0, Complete))
+        .printed_task(&task("b", 1, Incomplete).action(New))
+        .end();
+}
+
+#[test]
+fn after_task_by_name_that_matches_incomplete_and_complete_tasks_inserted_after_incomplete_tasks(
+) {
+    let mut fix = Fixture::default();
+    fix.test("todo new a --done");
+    fix.test("todo new a");
+    fix.test("todo new b --after a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(1, 1))
+        .printed_task(&task("b", 2, Blocked).action(New).deps_stats(1, 1))
+        .end();
+}
+
+#[test]
+fn after_task_by_name_that_matches_multiple_incomplete_tasks_inserted_after_all_tasks(
+) {
+    let mut fix = Fixture::default();
+    fix.test("todo new a a");
+    fix.test("todo new b --after a")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("a", 1, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("a", 2, Incomplete).adeps_stats(0, 1))
+        .printed_task(&task("b", 3, Blocked).action(New).deps_stats(2, 2))
+        .end();
+}
+
+#[test]
+fn by_task_by_name_that_matches_only_complete_task_inserted_by_that_task() {
+    let mut fix = Fixture::default();
+    fix.test("todo new a b c --chain");
+    fix.test("todo check a b");
+    fix.test("todo new d --by b")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("a", -1, Complete))
+        .printed_task(&task("d", 1, Incomplete).action(New).adeps_stats(1, 1))
+        .printed_task(&task("c", 2, Blocked).deps_stats(1, 3))
+        .end();
+}
+
+#[test]
+fn by_task_by_name_that_matches_incomplete_and_complete_tasks_inserted_by_incomplete_tasks(
+) {
+    let mut fix = Fixture::default();
+    fix.test("todo new a1 b c1 --chain -d");
+    fix.test("todo restore c1");
+    fix.test("todo new a2 b c2 --chain");
+    fix.test("todo new d --by b")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("a2", 2, Incomplete).adeps_stats(2, 3))
+        .printed_task(&task("d", 4, Blocked).action(New).deps_stats(1, 1))
+        .printed_task(&task("c2", 5, Blocked).deps_stats(1, 3))
+        .end()
+}
+
+#[test]
+fn by_task_by_name_that_matches_multiple_incomplete_tasks_inserted_by_all_tasks(
+) {
+    let mut fix = Fixture::default();
+    fix.test("todo new a1 b c1 --chain");
+    fix.test("todo new a2 b c2 --chain");
+    fix.test("todo new d --by b")
+        .modified(Mutated::Yes)
+        .validate()
+        .printed_task(&task("a1", 1, Incomplete).adeps_stats(1, 4))
+        .printed_task(&task("a2", 2, Incomplete).adeps_stats(1, 4))
+        .printed_task(&task("d", 5, Blocked).action(New).deps_stats(2, 2))
+        .printed_task(&task("c1", 6, Blocked).deps_stats(2, 4))
+        .printed_task(&task("c2", 7, Blocked).deps_stats(2, 4))
+        .end();
+}

--- a/builtin_apps/src/tests/testing.rs
+++ b/builtin_apps/src/tests/testing.rs
@@ -168,5 +168,5 @@ impl<'list> Fixture<'list> {
 }
 
 pub fn task(desc: &str, pos: i32, status: Status) -> PrintableTask<'_> {
-    PrintableTask::new(desc, pos, status)
+    PrintableTask::new(desc, pos, status).truncate_tags_if_needed(true)
 }

--- a/builtin_apps/src/util.rs
+++ b/builtin_apps/src/util.rs
@@ -98,7 +98,8 @@ pub fn format_task<'list>(
             Some(implicit_due_date),
         ) => {
             let mut result =
-                PrintableTask::new(&task.desc, pos, to_printing_status(status));
+                PrintableTask::new(&task.desc, pos, to_printing_status(status))
+                    .truncate_tags_if_needed(true);
             if implicit_priority != 0 {
                 result =
                     result.priority(if implicit_priority == task.priority {

--- a/builtin_apps/src/util.rs
+++ b/builtin_apps/src/util.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use {
     chrono::{DateTime, Duration, Local, Utc},
     std::convert::TryFrom,
@@ -7,7 +8,6 @@ use {
         BriefPrintableTask, Plicit, PrintableError, PrintableTask, Status,
     },
 };
-use std::collections::HashMap;
 
 fn to_printing_status(status: TaskStatus) -> Status {
     match status {
@@ -198,7 +198,9 @@ pub fn lookup_tasks_by_keys<'a>(
     list: &'a TodoList,
     keys: impl IntoIterator<Item = &'a Key>,
 ) -> HashMap<&'a Key, TaskSet> {
-    keys.into_iter().map(|key| (key, lookup_task(list, key))).collect()
+    keys.into_iter()
+        .map(|key| (key, lookup_task(list, key)))
+        .collect()
 }
 
 fn any_tasks_are_complete(

--- a/printing/src/lib.rs
+++ b/printing/src/lib.rs
@@ -7,6 +7,7 @@ mod printable_warning;
 mod scripting_todo_printer;
 mod simple_todo_printer;
 mod todo_printer;
+mod truncate;
 
 pub use self::brief_printable_task::*;
 pub use self::printable_error::*;
@@ -95,4 +96,5 @@ mod tests {
     mod printable_task_test;
     mod printable_warning_test;
     mod simple_todo_printer_test;
+    mod truncate_test;
 }

--- a/printing/src/printable_error.rs
+++ b/printing/src/printable_error.rs
@@ -33,6 +33,7 @@ pub enum PrintableError {
     },
     CannotEditBecauseInvalidLine {
         malformed_line: String,
+        explanation: String,
     },
     FailedToUseTextEditor,
     NoMatchForKeys {
@@ -101,7 +102,12 @@ impl Display for PrintableError {
                 } => format!("No task with number {})", requested),
                 PrintableError::CannotEditBecauseInvalidLine{
                     malformed_line,
-                } => format!("Could not parse line: \"{}\"", malformed_line),
+                    explanation,
+                } => format!(
+                    "Could not parse line: \"{}\"; {}",
+                    malformed_line,
+                    explanation,
+                ),
                 PrintableError::FailedToUseTextEditor => {
                     "Failed to open text editor".to_string()
                 }

--- a/printing/src/printable_task.rs
+++ b/printing/src/printable_task.rs
@@ -96,6 +96,7 @@ pub struct PrintableTask<'a> {
     pub adeps_stats: (usize, usize),
     pub is_explicit_tag: bool,
     pub implicit_tags: Vec<&'a str>,
+    pub truncate_tags_if_needed: bool,
 }
 
 impl<'a> PrintableTask<'a> {
@@ -160,6 +161,11 @@ impl<'a> PrintableTask<'a> {
 
     pub fn tag(mut self, tag: &'a str) -> Self {
         self.implicit_tags.push(tag);
+        self
+    }
+
+    pub fn truncate_tags_if_needed(mut self, truncate: bool) -> Self {
+        self.truncate_tags_if_needed = truncate;
         self
     }
 }

--- a/printing/src/simple_todo_printer.rs
+++ b/printing/src/simple_todo_printer.rs
@@ -266,7 +266,9 @@ fn get_body(
             }
             body.push_str(SEPARATOR);
             body.push(' ');
-            for tag in task.implicit_tags[right..].iter() {
+            for tag in
+                task.implicit_tags[task.implicit_tags.len() - right..].iter()
+            {
                 fmt_tag(Plicit::Implicit(tag), &mut body);
             }
         }

--- a/printing/src/simple_todo_printer.rs
+++ b/printing/src/simple_todo_printer.rs
@@ -246,13 +246,16 @@ fn get_body(
     if let Some(punctuality) = task.punctuality {
         fmt_punctuality(punctuality, &mut body);
     }
-    let remaining_width = context.width - prefix_length - body.len() - 1;
+    let remaining_width = context.width
+        - prefix_length
+        - textwrap::core::display_width(&body)
+        - 1;
     const SEPARATOR: &str = "...";
     use TruncationIndices::*;
     match truncation_indices(
         remaining_width,
         SEPARATOR.len(),
-        task.implicit_tags.iter().map(|tag| tag.len()),
+        task.implicit_tags.iter().copied().map(textwrap::core::display_width),
     ) {
         Empty => (),
         NoTruncation => {
@@ -298,7 +301,11 @@ fn get_subsequent_indent(
 impl<'a> Display for PrintableTaskWithContext<'a> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         let start = get_initial_indent(self.task, self.context);
-        let body = get_body(self.task, self.context, start.len());
+        let body = get_body(
+            self.task,
+            self.context,
+            textwrap::core::display_width(&start),
+        );
         if body.is_empty() {
             return f.write_str(start.trim_end());
         }

--- a/printing/src/tests/printable_task_test.rs
+++ b/printing/src/tests/printable_task_test.rs
@@ -645,3 +645,58 @@ fn do_not_split_url() {
         )
     );
 }
+
+#[test]
+fn truncate_tags_if_they_do_not_fit_on_line() {
+    let context = PrintingContext {
+        max_index_digits: 3,
+        width: 45,
+        now: Utc::now(),
+    };
+    let fmt = print_task_with_context(
+        context,
+        &PrintableTask::new("a", 1, Incomplete)
+            .tag("project-stardust")
+            .tag("project-zeppelin")
+            .tag("project-apollo")
+            .truncate_tags_if_needed(true),
+    );
+    // Tags are truncated to "project-stardust ... project-apollo"
+    assert_eq!(
+        fmt,
+        concat!(
+            "      \u{1b}[33m1)\u{1b}[0m ",
+            "\u{1b}[3;38;5;9mproject-stardust\u{1b}[0m ",
+            "... ",
+            "\u{1b}[3;38;5;12mproject-apollo\u{1b}[0m\n",
+            "         a\n",
+        )
+    );
+}
+
+#[test]
+fn do_not_truncate_tags_if_not_opted_in() {
+    let context = PrintingContext {
+        max_index_digits: 3,
+        width: 45,
+        now: Utc::now(),
+    };
+    let fmt = print_task_with_context(
+        context,
+        &PrintableTask::new("a", 1, Incomplete)
+            .tag("project-stardust")
+            .tag("project-zeppelin")
+            .tag("project-apollo"),
+    );
+    // "project-stardust project-zeppelin project-apollo" don't fit on one line,
+    // so "project-apollo" is moved to the next line.
+    assert_eq!(
+        fmt,
+        concat!(
+            "      \u{1b}[33m1)\u{1b}[0m ",
+            "\u{1b}[3;38;5;9mproject-stardust\u{1b}[0m ",
+            "\u{1b}[3;38;5;1mproject-zeppelin\u{1b}[0m\n",
+            "         \u{1b}[3;38;5;12mproject-apollo\u{1b}[0m a\n",
+        )
+    );
+}

--- a/printing/src/tests/truncate_test.rs
+++ b/printing/src/tests/truncate_test.rs
@@ -1,0 +1,64 @@
+use crate::truncate::truncate;
+
+#[test]
+fn truncate_empty_list() {
+    let actual = truncate(20, "...", &[]);
+    let expected: Vec<&str> = vec![];
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn single_word_fits() {
+    let actual = truncate(20, "...", &["word"]);
+    let expected = vec!["word"];
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn two_words_fit() {
+    let actual = truncate(20, "...", &["foo", "bar"]);
+    let expected = vec!["foo", "bar"];
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn truncate_two_words_with_separator() {
+    let actual = truncate(12, "...", &["foo", "bar", "baz", "qux"]);
+    let expected = vec!["foo", "...", "qux"];
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn truncate_three_words_with_separator() {
+    let actual = truncate(12, "...", &["foo", "bar", "baz", "qux", "quux"]);
+    let expected = vec!["foo", "...", "quux"];
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn fits_within_max_width() {
+    let actual = truncate(20, "...", &["foo", "bar", "baz"]);
+    let expected = vec!["foo", "bar", "baz"];
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn right_end_does_not_fit() {
+    let actual = truncate(12, "...", &["foo", "bar", "abcdefghijkl"]);
+    let expected = vec!["foo", "bar", "..."];
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn left_end_does_not_fit() {
+    let actual = truncate(12, "...", &["abcdefghijkl", "bar", "baz"]);
+    let expected = vec!["...", "bar", "baz"];
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn truncation_separator_larger_than_max_width() {
+    let actual = truncate(2, "...", &["foo", "bar", "baz"]);
+    let expected: Vec<&str> = vec![];
+    assert_eq!(actual, expected);
+}

--- a/printing/src/truncate.rs
+++ b/printing/src/truncate.rs
@@ -1,0 +1,168 @@
+pub enum TruncationIndices {
+    Empty,
+    Truncate(usize, usize),
+    NoTruncation,
+}
+
+/// Returns the positions wheere the inputs need to be culled from the middle
+/// to fit into the given width.
+///
+/// If both elements of the output tuple are `None`, then the inputs fit into
+/// the width without truncation.
+///
+/// If the first element is `Some`, then the input needs to be truncated at the
+/// given index from the left.
+///
+/// If the second element is `Some`, then the input needs to be truncated at the
+/// given index from the right.
+pub fn truncation_indices(
+    max_weight: usize,
+    truncation_separator_width: usize,
+    mut weights: impl DoubleEndedIterator<Item = usize>,
+) -> TruncationIndices {
+    use TruncationIndices::*;
+    // If the separator doesn't fit, we can't fit anything.
+    if truncation_separator_width >= max_weight {
+        return Empty;
+    }
+    // Assume that the separator string is in the middle, so deduct its length
+    // from the maximum weight. We will add the separator width back to the
+    // max weight if we are on the last word and it doesn't fit with the
+    // separator, but may fit without the separator.
+    let max_weight = max_weight - truncation_separator_width;
+    let mut left = 0;
+    let mut right = 0;
+    let mut left_weight = 0;
+    let mut right_weight = 0;
+
+    loop {
+        match (weights.next(), weights.next_back()) {
+            (Some(weight_l), Some(weight_r)) => {
+                // Choose the side that has the smallest cumulative weight.
+                if left_weight + weight_l <= right_weight + weight_r {
+                    if left_weight + right_weight + weight_l < max_weight {
+                        left_weight += weight_l + 1;
+                        left += 1;
+                    } else {
+                        // We have found that the left word will not fit, and
+                        // that the left word is shorter than the right word,
+                        // so we will not be able to fit the right word either.
+                        // Therefore, truncate at the current position.
+                        return Truncate(left, right);
+                    }
+                    if left_weight + right_weight + weight_r < max_weight {
+                        right_weight += weight_r + 1;
+                        right += 1;
+                    }
+                    // At this point we know the right word will never fit, but
+                    // more words may fit on the left side. Iterate through the
+                    // rest of the words to find the last word that fits.
+                    else {
+                        for weight in weights.by_ref() {
+                            if left_weight + right_weight + weight < max_weight
+                            {
+                                left_weight += weight + 1;
+                                left += 1;
+                            } else {
+                                return Truncate(left, right);
+                            }
+                        }
+                        return Truncate(left, right);
+                    }
+                } else {
+                    if left_weight + right_weight + weight_r < max_weight {
+                        right_weight += weight_r + 1;
+                        right += 1;
+                    } else {
+                        // We have found that the right word will not fit, and
+                        // that the right word is shorter than the left word,
+                        // so we will not be able to fit the left word either.
+                        // Therefore, truncate at the current position.
+                        return Truncate(left, right);
+                    }
+                    if left_weight + right_weight + weight_l < max_weight {
+                        left_weight += weight_l + 1;
+                        left += 1;
+                    } else {
+                        // At this point we know the left word will never fit,
+                        // but more words may fit on the right side. Iterate
+                        // through the rest of the words to find the last word
+                        // that fits.
+                        for weight in weights.by_ref().rev() {
+                            if left_weight + right_weight + weight < max_weight
+                            {
+                                right_weight += weight + 1;
+                                right += 1;
+                            } else {
+                                return Truncate(left, right);
+                            }
+                        }
+                        return Truncate(left, right);
+                    }
+                }
+            }
+            (Some(weight), None) | (None, Some(weight)) => {
+                if left_weight + right_weight + weight + 2 <= max_weight {
+                    // We reached the middle, and the last element fits, so no
+                    // truncation is needed.
+                    return NoTruncation;
+                } else {
+                    // We reached the middle, but the last element doesn't fit,
+                    // so we need to truncate.
+                    return Truncate(left, right);
+                }
+            }
+            (None, None) => {
+                // We reached the middle, and there are no more elements.
+                return NoTruncation;
+            }
+        }
+    }
+}
+
+/// Truncate the items so that they will fit into the given width when printed
+/// together, separated by spaces.
+///
+/// If the combined length of the items is less than or equal to `max_width`,
+/// items are chopped out of the middle until the remainder fit.
+///
+/// The `separator` is inserted between the items when they are truncated. There
+/// is only at most one separator in the entire output.
+///
+/// This works by implementing a greedy algorithm that tries to fit as many items
+/// as possible into the output, from either end of the input list, while trying
+/// to keep the cumulative length of either end "balanced" so that the separator
+/// is placed in the middle of the output if it is needed.
+///
+/// If the input list is empty, the output list will also be empty.
+///
+/// If the input list fits into `max_width` without truncation, the output list
+/// will be the same as the input list.
+///
+/// If the left end of the input fits and the right end does not, or vice-versa,
+/// the output list will contain the longest end that fits with the separator
+/// on the other end.
+///
+/// If neither end fits, the output list will just contain the separator.
+///
+/// If the separator doesn't even fit, the output list will be empty.
+#[allow(unused)]
+pub fn truncate<'a>(
+    max_width: usize,
+    separator: &'a str,
+    words: &[&'a str],
+) -> Vec<&'a str> {
+    let weights = words.iter().map(|word| word.len());
+    let indices = truncation_indices(max_width, separator.len(), weights);
+
+    match indices {
+        TruncationIndices::Empty => vec![],
+        TruncationIndices::NoTruncation => words.to_vec(),
+        TruncationIndices::Truncate(left, right) => {
+            let mut result = words[0..left].to_vec();
+            result.push(separator);
+            result.extend(&words[words.len() - right..]);
+            result
+        }
+    }
+}

--- a/printing/src/truncate.rs
+++ b/printing/src/truncate.rs
@@ -4,7 +4,7 @@ pub enum TruncationIndices {
     NoTruncation,
 }
 
-/// Returns the positions wheere the inputs need to be culled from the middle
+/// Returns the positions where the inputs need to be culled from the middle
 /// to fit into the given width.
 ///
 /// If both elements of the output tuple are `None`, then the inputs fit into

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 clap.workspace = true
 directories.workspace = true
+either.workspace = true
 serde_json.workspace = true
 terminal_size.workspace = true
 thiserror.workspace = true

--- a/runner/src/less.rs
+++ b/runner/src/less.rs
@@ -6,7 +6,7 @@ pub struct Less {
 }
 
 #[derive(Debug)]
-pub struct CouldNotSpawnPaginator(std::io::Error);
+pub struct CouldNotSpawnPaginator(pub std::io::Error);
 
 impl Less {
     pub fn new(cmd: &[String]) -> Result<Self, CouldNotSpawnPaginator> {


### PR DESCRIPTION
Truncation is done by greedily adding tags from the front and back of
the list of tags until they meet in the middle at the capacity of the
line, including space for the truncation delimiter string. The algorithm
tries to balance the left and right sides of the truncation point by
always choosing the tag that makes its respective side of the truncation
point shortest when added.

There are a surprising number of edge cases and errors that need to be
considered, so there are unit tests in truncate_test.rs.

I should make sure to also add tests for simple_todo_printer.rs printing
truncateed tags.

I think it's likely that I'll want to toggle this behavior on and off
in certain circumstances. For example, maybe tasks that are matches for
a 'todo get' query should not truncate their tags so the user can see
the full set of tags when inspecting a task directly. Or the user may
wish to use the config file to disable this behavior entirely, or change
the delimiter character.