### PR TITLE
Snoozing a task until before its snooze date is a no-op.

### DIFF
--- a/builtin_apps/src/snooze.rs
+++ b/builtin_apps/src/snooze.rs
@@ -17,11 +17,23 @@ fn format_snooze_warning(
     warning: SnoozeWarning,
 ) -> PrintableWarning {
     match warning {
+        SnoozeWarning::TaskNotFound { id } => {
+            // This should never happen, as we've already looked up the task.
+            unreachable!("Task not found: {id:?}");
+        }
         SnoozeWarning::TaskIsComplete => {
             PrintableWarning::CannotSnoozeBecauseComplete {
                 cannot_snooze: format_task_brief(list, id),
             }
         }
+        SnoozeWarning::TaskIsAlreadySnoozed {
+            current_snooze,
+            requested_snooze,
+        } => PrintableWarning::AlreadySnoozedAfterRequestedTime {
+            snoozed_task: format_task_brief(list, id),
+            requested_snooze_date: requested_snooze,
+            snooze_date: current_snooze,
+        },
         SnoozeWarning::SnoozedUntilAfterDueDate {
             snoozed_until,
             due_date,
@@ -85,6 +97,12 @@ pub fn run<'list>(
                                         snoozed_until: _, due_date: _
                                     } = w {
                                         mutated = true;
+                                        snoozed.push(id);
+                                    }
+                                    if let SnoozeWarning::TaskIsAlreadySnoozed {
+                                        current_snooze: _,
+                                        requested_snooze: _,
+                                    } = w {
                                         snoozed.push(id);
                                     }
                                 })

--- a/builtin_apps/src/tests/snooze_test.rs
+++ b/builtin_apps/src/tests/snooze_test.rs
@@ -153,6 +153,27 @@ fn snooze_until_time_that_has_already_passed_should_leave_tasks_unmodified() {
 }
 
 #[test]
+fn snooze_until_earlier_than_current_snooze_date_is_no_op_with_warning() {
+    let mut fix = Fixture::default();
+    fix.clock.now = ymdhms(2024, 05, 19, 14, 00, 00);
+    fix.test("todo new a --snooze 2 days");
+    fix.test("todo snooze a --until 1 day")
+        .modified(Mutated::No)
+        .validate()
+        .printed_warning(&PrintableWarning::AlreadySnoozedAfterRequestedTime {
+            snoozed_task: BriefPrintableTask::new(1, Blocked),
+            requested_snooze_date: ymdhms(2024, 05, 20, 00, 00, 00),
+            snooze_date: ymdhms(2024, 05, 21, 00, 00, 00),
+        })
+        .printed_task(
+            &task("a", 1, Blocked)
+                .start_date(ymdhms(2024, 05, 21, 00, 00, 00))
+                .action(Snooze),
+        )
+        .end();
+}
+
+#[test]
 fn snoozed_tasks_should_appear_before_tasks_they_block() {
     let mut fix = Fixture::default();
     fix.clock.now = ymdhms(2023, 09, 30, 14, 00, 00);

--- a/printing/src/printable_warning.rs
+++ b/printing/src/printable_warning.rs
@@ -38,6 +38,11 @@ pub enum PrintableWarning {
         due_date: DateTime<Utc>,
         snooze_date: DateTime<Utc>,
     },
+    AlreadySnoozedAfterRequestedTime {
+        snoozed_task: BriefPrintableTask,
+        requested_snooze_date: DateTime<Utc>,
+        snooze_date: DateTime<Utc>,
+    },
     SnoozedUntilPast {
         snoozed_task: BriefPrintableTask,
         snooze_date: DateTime<Utc>,
@@ -95,6 +100,15 @@ impl Display for PrintableWarning {
                 f,
                 "Snoozed {} until after its due date {}",
                 snoozed_task, due_date
+            ),
+            AlreadySnoozedAfterRequestedTime {
+                snoozed_task,
+                requested_snooze_date,
+                snooze_date,
+            } => write!(
+                f,
+                "Already snoozed {} until {} which is after requested time {}",
+                snoozed_task, snooze_date, requested_snooze_date
             ),
             SnoozedUntilPast {
                 snoozed_task,


### PR DESCRIPTION
Most of the time snoozing an already-snoozed task happens as a result of
a scripting query like 'todo snooze $(todo get work) --until tomorrow'
where some of the tasks that match the 'get' query are already snoozed.

If the new snooze date overrides the old one in cases like this, you can
get bombarded with more unsnoozed tasks than expected when the snooze
date arrives.

Now, if the new snooze date is before the old one, the snooze operation
is a no-op, but a warning is printed to let the user know that the task
was already snoozed until a later date. If this warning message becomes
too annoying I may change or remove it.