### PR TITLE
Default to a due date of today for 'todo due'.

### DIFF
--- a/builtin_apps/src/tests/due_test.rs
+++ b/builtin_apps/src/tests/due_test.rs
@@ -9,18 +9,34 @@ use {
 };
 
 #[test]
-fn show_tasks_with_due_date() {
+fn show_tasks_due_today() {
     let mut fix = Fixture::default();
     fix.clock.now = ymdhms(2021, 04, 12, 14, 00, 00);
-    let in_1_day = ymdhms(2021, 04, 13, 23, 59, 59);
-    fix.test("todo new a b c --due 1 day");
+    let end_of_day = ymdhms(2021, 04, 12, 23, 59, 59);
+    fix.test("todo new a b c --due today");
     fix.test("todo new d e f");
     fix.test("todo due")
         .modified(Mutated::No)
         .validate()
-        .printed_task(&task("a", 1, Incomplete).due_date(Explicit(in_1_day)))
-        .printed_task(&task("b", 2, Incomplete).due_date(Explicit(in_1_day)))
-        .printed_task(&task("c", 3, Incomplete).due_date(Explicit(in_1_day)))
+        .printed_task(&task("a", 1, Incomplete).due_date(Explicit(end_of_day)))
+        .printed_task(&task("b", 2, Incomplete).due_date(Explicit(end_of_day)))
+        .printed_task(&task("c", 3, Incomplete).due_date(Explicit(end_of_day)))
+        .end();
+}
+
+#[test]
+fn tasks_due_later_than_eod_not_included_without_flag() {
+    let mut fix = Fixture::default();
+    fix.clock.now = ymdhms(2021, 04, 12, 14, 00, 00);
+    let end_of_day = ymdhms(2021, 04, 12, 23, 59, 59);
+    fix.test("todo new a b c --due today");
+    fix.test("todo new d e f --due tomorrow");
+    fix.test("todo due")
+        .modified(Mutated::No)
+        .validate()
+        .printed_task(&task("a", 1, Incomplete).due_date(Explicit(end_of_day)))
+        .printed_task(&task("b", 2, Incomplete).due_date(Explicit(end_of_day)))
+        .printed_task(&task("c", 3, Incomplete).due_date(Explicit(end_of_day)))
         .end();
 }
 
@@ -34,7 +50,7 @@ fn show_tasks_with_due_date_includes_blocked() {
     fix.test("todo new b -p a");
     fix.test("todo new c -p b --due 2 days");
     fix.test("todo new d e f");
-    fix.test("todo due -b")
+    fix.test("todo due -b --in 2 days")
         .modified(Mutated::No)
         .validate()
         .printed_task(
@@ -65,7 +81,7 @@ fn show_tasks_with_due_date_excludes_complete_and_blocked() {
     fix.test("todo new c -p b --due 2 days");
     fix.test("todo new d e f");
     fix.test("todo check a");
-    fix.test("todo due")
+    fix.test("todo due --in 2 days")
         .modified(Mutated::No)
         .validate()
         .printed_task(
@@ -86,7 +102,7 @@ fn show_tasks_with_due_date_include_done() {
     fix.test("todo new c -p b --due 2 days");
     fix.test("todo new d e f");
     fix.test("todo check a");
-    fix.test("todo due --include-done")
+    fix.test("todo due --include-done --in 2 days")
         .modified(Mutated::No)
         .validate()
         .printed_task(

--- a/cli/src/subcommands/due.rs
+++ b/cli/src/subcommands/due.rs
@@ -14,7 +14,7 @@ use {clap::Parser, todo_lookup_key::Key};
 /// printed.
 ///
 /// If neither task keys nor a due date is provided, this will print all
-/// tasks that have due dates, implicit or explicit. I.e.
+/// tasks that are due today, implicitly or explicitly. I.e.
 ///
 ///   todo due
 ///
@@ -44,7 +44,7 @@ pub struct Due {
     /// This is a human-readable description of a date or time, like "1 day" or
     /// "5pm".
     #[arg(long, alias = "in", alias = "on", num_args = 1..)]
-    pub due: Vec<String>,
+    pub due: Option<Vec<String>>,
     /// Remove the explicit due date. If the implicit due date is inherited from
     /// an antidependency, it is retained.
     #[arg(long)]

--- a/cli/src/subcommands/tests/due_test.rs
+++ b/cli/src/subcommands/tests/due_test.rs
@@ -24,7 +24,7 @@ fn due_with_date_but_no_keys() {
     expect_parses_into(
         "todo due --in 2 days",
         SubCommand::Due(Due {
-            due: vec!["2".to_string(), "days".to_string()],
+            due: Some(vec!["2".to_string(), "days".to_string()]),
             ..Default::default()
         }),
     );
@@ -36,7 +36,7 @@ fn due_with_keys_and_date() {
         "todo due 10 --on friday",
         SubCommand::Due(Due {
             keys: vec![ByNumber(10)],
-            due: vec!["friday".to_string()],
+            due: Some(vec!["friday".to_string()]),
             ..Default::default()
         }),
     );


### PR DESCRIPTION
I find myself caring about things due today far more often than any other specific due date, or caring about all things that have some due date, so this is a more useful default.