### PR TITLE
Fix clippy lint in runner crate.

### DIFF
--- a/runner/src/lib.rs
+++ b/runner/src/lib.rs
@@ -84,10 +84,13 @@ pub fn run(app: impl Application) -> TodoResult {
 
     let mutated = if std::io::stdout().is_terminal() {
         use either::{Left, Right};
-        let out = match less::Less::new(&config.paginator_cmd) {
+        let paginator_cmd = &config.paginator_cmd;
+        let out = match less::Less::new(paginator_cmd) {
             Ok(paginator) => Left(paginator),
-            Err(e) => {
-                eprintln!("Could not spawn paginator: {e:?}");
+            Err(less::CouldNotSpawnPaginator(e)) => {
+                eprintln!(
+                    "Could not spawn paginator using {paginator_cmd:?}: {e:?}"
+                );
                 Right(std::io::stdout())
             }
         };


### PR DESCRIPTION
The new lint gives a warning when a field is never read outside a Debug derive, which doesn't count. This patch fixes it by explicitly extracting the inner field from the error struct.

This also adds the command that failed to spawn a paginator to the error message to help the user debug the problem if they misconfigured the paginator.