### PR TITLE
Cache the task status in a persistable field.

### DIFF
--- a/model/src/task.rs
+++ b/model/src/task.rs
@@ -7,6 +7,7 @@ use serde_derive::Serialize;
 
 use crate::DurationInSeconds;
 use crate::TaskId;
+use crate::TaskStatus;
 
 fn default_creation_time() -> DateTime<Utc> {
     Utc::now()
@@ -22,6 +23,9 @@ pub struct Task<'ser> {
     pub creation_time: DateTime<Utc>,
     #[serde(default)]
     pub completion_time: Option<DateTime<Utc>>,
+    // Status is cached here for performance
+    #[serde(default)]
+    pub cached_status: Option<TaskStatus>,
     #[serde(default)]
     pub priority: i32,
     #[serde(default)]
@@ -137,6 +141,7 @@ impl<'ser> Task<'ser> {
             start_date: options.start_date.unwrap_or(options.now),
             tag: options.tag,
             implicit_tags: vec![],
+            cached_status: None,
         }
     }
 

--- a/model/src/task_status.rs
+++ b/model/src/task_status.rs
@@ -1,4 +1,7 @@
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Deserialize, Serialize)]
 pub enum TaskStatus {
     Complete,
     Incomplete,

--- a/model/src/todo_list_test/status_test.rs
+++ b/model/src/todo_list_test/status_test.rs
@@ -1,10 +1,140 @@
 use super::*;
+use chrono::Utc;
+use todo_testing::ymdhms;
 
 #[test]
 fn status_of_incomplete_task() -> TestResult {
     let mut list = TodoList::default();
     let a = list.add("a");
     assert_eq!(list.status(a), Some(TaskStatus::Incomplete));
+    Ok(())
+}
+
+#[test]
+fn status_is_persisted_incomplete() -> TestResult {
+    use serde_json;
+    let mut list = TodoList::default();
+    let a = list.add("a");
+
+    // Get status to cache it
+    assert_eq!(list.status(a), Some(TaskStatus::Incomplete));
+
+    // Serialize and deserialize
+    let json = serde_json::to_string(&list).unwrap();
+    let list: TodoList = serde_json::from_str(&json).unwrap();
+
+    // Status should still be cached
+    assert_eq!(list.status(a), Some(TaskStatus::Incomplete));
+    Ok(())
+}
+
+#[test]
+fn status_is_persisted_blocked() -> TestResult {
+    use serde_json;
+    let mut list = TodoList::default();
+    let a = list.add("a");
+    let b = list.add("b");
+    list.block(b).on(a)?;
+
+    // Get status to cache it
+    assert_eq!(list.status(b), Some(TaskStatus::Blocked));
+
+    // Serialize and deserialize
+    let json = serde_json::to_string(&list).unwrap();
+    let list: TodoList = serde_json::from_str(&json).unwrap();
+
+    // Status should still be cached
+    assert_eq!(list.status(b), Some(TaskStatus::Blocked));
+    Ok(())
+}
+
+#[test]
+fn status_is_persisted_snoozed() -> TestResult {
+    use serde_json;
+    let mut list = TodoList::default();
+    let a = list.add(
+        NewOptions::new()
+            .desc("a")
+            .creation_time(ymdhms(2024, 12, 15, 12, 00, 00)),
+    );
+    list.snooze(a, ymdhms(2024, 12, 15, 16, 00, 00)).unwrap(); // 4 hours later
+
+    // Get status to cache it
+    assert_eq!(list.status(a), Some(TaskStatus::Blocked));
+
+    // Serialize and deserialize
+    let json = serde_json::to_string(&list).unwrap();
+    let list: TodoList = serde_json::from_str(&json).unwrap();
+
+    // Status should still be cached
+    assert_eq!(list.status(a), Some(TaskStatus::Blocked));
+    Ok(())
+}
+
+#[test]
+fn status_is_persisted_blocked_and_snoozed() -> TestResult {
+    use serde_json;
+    let mut list = TodoList::default();
+    let a = list.add(
+        NewOptions::new()
+            .desc("a")
+            .creation_time(ymdhms(2024, 12, 15, 12, 00, 00)),
+    );
+    let b = list.add(
+        NewOptions::new()
+            .desc("b")
+            .creation_time(ymdhms(2024, 12, 15, 12, 00, 00)),
+    );
+    list.snooze(a, ymdhms(2024, 12, 15, 16, 00, 00)).unwrap(); // 4 hours later
+    list.block(b).on(a)?;
+
+    // Get status to cache it
+    assert_eq!(list.status(b), Some(TaskStatus::Blocked));
+
+    // Serialize and deserialize
+    let json = serde_json::to_string(&list).unwrap();
+    let list: TodoList = serde_json::from_str(&json).unwrap();
+
+    // Status should still be cached
+    assert_eq!(list.status(b), Some(TaskStatus::Blocked));
+    Ok(())
+}
+
+#[test]
+fn status_is_persisted_complete() -> TestResult {
+    use serde_json;
+    let mut list = TodoList::default();
+    let a = list.add("a");
+    list.check(a)?;
+
+    // Get status to cache it
+    assert_eq!(list.status(a), Some(TaskStatus::Complete));
+
+    // Serialize and deserialize
+    let json = serde_json::to_string(&list).unwrap();
+    let list: TodoList = serde_json::from_str(&json).unwrap();
+
+    // Status should still be cached
+    assert_eq!(list.status(a), Some(TaskStatus::Complete));
+    Ok(())
+}
+
+#[test]
+fn status_of_snoozed_task_after_deps_completed() -> TestResult {
+    use chrono::Duration;
+    let mut list = TodoList::default();
+    let now = Utc::now();
+    let a = list.add("a");
+    let b = list.add("b");
+    list.block(b).on(a)?;
+    list.snooze(b, now + Duration::hours(1)).unwrap();
+    // Two hours later, complete a
+    list.check(CheckOptions {
+        id: a,
+        now: now + Duration::hours(2),
+    })?;
+    // b should be unblocked since both the snooze and the dep are done
+    assert_eq!(list.status(b), Some(TaskStatus::Incomplete));
     Ok(())
 }
 


### PR DESCRIPTION
The status() function that computed the status by first checking for presence in the completion list was an O(n) lookup which was a bottleneck when running `todo` or `todo -a` or `todo log` which would essentially run the lookup on all tasks.

This change introduces a cached status field that is updated when the status changes (tasks become blocked/unblocked/complete/etc) and short-circuits this to an O(1) lookup.